### PR TITLE
feat: implement suspend function

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -11,3 +11,8 @@ import "os"
 func OpenTTY() (inTty, outTty *os.File, err error) {
 	return openTTY()
 }
+
+// Suspend suspends the current process group.
+func Suspend() error {
+	return suspend()
+}

--- a/tty_other.go
+++ b/tty_other.go
@@ -8,3 +8,7 @@ import "os"
 func openTTY() (*os.File, *os.File, error) {
 	return nil, nil, ErrPlatformNotSupported
 }
+
+func suspend() error {
+	return ErrPlatformNotSupported
+}

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -3,7 +3,11 @@
 
 package uv
 
-import "os"
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
 
 func openTTY() (inTty, outTty *os.File, err error) {
 	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
@@ -11,4 +15,14 @@ func openTTY() (inTty, outTty *os.File, err error) {
 		return nil, nil, err
 	}
 	return f, f, nil
+}
+
+func suspend() (err error) {
+	// Send SIGTSTP to the entire process group.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGCONT)
+	err = syscall.Kill(0, syscall.SIGTSTP)
+	// blocks until a CONT happens...
+	<-c
+	return
 }

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -19,3 +19,9 @@ func openTTY() (inTty, outTty *os.File, err error) {
 	}
 	return inTty, outTty, nil
 }
+
+func suspend() (err error) {
+	// On Windows, suspending the process group is not supported in the same
+	// way as Unix-like systems.
+	return nil
+}


### PR DESCRIPTION
This adds a static process group suspend functionality. The caller is responsible for restoring the terminal state.