### PR TITLE
perf: Improve rendering performance with more efficient hashing

### DIFF
--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -3,6 +3,7 @@ package uv
 import (
 	"bytes"
 	"errors"
+	"hash/maphash"
 	"io"
 	"strings"
 
@@ -130,6 +131,7 @@ type TerminalRenderer struct {
 	buf              *bytes.Buffer // buffer for writing to the screen
 	curbuf           *Buffer       // the current buffer
 	tabs             *TabStops
+	hasher           maphash.Hash
 	oldhash, newhash []uint64     // the old and new hash values for each line
 	hashtab          []hashmap    // the hashmap table
 	oldnum           []int        // old indices from previous hash


### PR DESCRIPTION
*This is one of a series of changes related to https://github.com/charmbracelet/crush/issues/691*

------

The previous hash implementation performed UTF-8 decoding on the cell's `string`, which leads to lots of copying. In `crush`, this caused situations where `hash` was responsible for 10% (!) of CPU time.

Using the standard library's maphash is several times more efficient, eliminating this function's significant footprint in flamegraphs.

## Some notes

I think there might be some other strange bug in this code, as indicated by the TODO-comment about rehashing old lines. Maybe the "old new" renderer state is not correctly being reassigned as "old old"? I couldn't from a brief glance figure out where exactly this happens, though.

Another thing is that I'm not convinced that hashing is necessary here at all. As I understood the types, the cell always contains a single "visible character", so the strings are unlikely to be large and it might be easier to just compare them directly. That's only a theory - needs measuring :)

### Related issue/discussion:

https://github.com/charmbracelet/crush/pull/687

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code