### PR TITLE
feat: use xxhash instead of maphash (small strings (like terminal cel…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/charmbracelet/ultraviolet
 go 1.24.0
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/charmbracelet/colorprofile v0.3.1
 	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/charmbracelet/x/term v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/colorprofile v0.3.1 h1:k8dTHMd7fgw4bnFd7jXTLZrSU/CQrKnL3m+AxCzDz40=
 github.com/charmbracelet/colorprofile v0.3.1/go.mod h1:/GkGusxNs8VB/RSOh3fu0TJmQ4ICMMPApIIVn0KszZ0=
-github.com/charmbracelet/x/ansi v0.10.1 h1:rL3Koar5XvX0pHGfovN03f5cxLbCF2YvLeyz7D2jVDQ=
+github.com/charmbracelet/x/ansi v0.10.1 h1:LT77A3bpevRD0yZ5NDR5nonS7N83mxzzGwuZcTGezLE=
 github.com/charmbracelet/x/ansi v0.10.1/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -3,7 +3,7 @@ package uv
 import (
 	"bytes"
 	"errors"
-	"hash/maphash"
+	"github.com/cespare/xxhash/v2"
 	"io"
 	"strings"
 
@@ -131,7 +131,7 @@ type TerminalRenderer struct {
 	buf              *bytes.Buffer // buffer for writing to the screen
 	curbuf           *Buffer       // the current buffer
 	tabs             *TabStops
-	hasher           maphash.Hash
+	hasher           *xxhash.Digest
 	oldhash, newhash []uint64     // the old and new hash values for each line
 	hashtab          []hashmap    // the hashmap table
 	oldnum           []int        // old indices from previous hash
@@ -172,6 +172,7 @@ func NewTerminalRenderer(w io.Writer, env []string) (s *TerminalRenderer) {
 	s.saved = s.cur
 	s.scrollHeight = 0
 	s.oldhash, s.newhash = nil, nil
+	s.hasher = xxhash.New()
 	return
 }
 

--- a/terminal_renderer_hashmap.go
+++ b/terminal_renderer_hashmap.go
@@ -1,12 +1,12 @@
 package uv
 
-import "hash/maphash"
+import "github.com/cespare/xxhash/v2"
 
 // hash returns the hash value of a [Line].
-func hash(h *maphash.Hash, l Line) uint64 {
+func hash(h *xxhash.Digest, l Line) uint64 {
 	h.Reset()
 	for _, c := range l {
-		// maphash writes can not fail
+		// xxhash writes can not fail
 		_, _ = h.WriteString(c.Content)
 	}
 
@@ -34,8 +34,8 @@ func (s *TerminalRenderer) updateHashmap(newbuf *Buffer) {
 				// TODO: Investigate why this is needed. If we remove this
 				// line, scroll optimization does not work correctly. This
 				// should happen else where.
-				s.oldhash[i] = hash(&s.hasher, s.curbuf.Line(i))
-				s.newhash[i] = hash(&s.hasher, newbuf.Line(i))
+				s.oldhash[i] = hash(s.hasher, s.curbuf.Line(i))
+				s.newhash[i] = hash(s.hasher, newbuf.Line(i))
 			}
 		}
 	} else {
@@ -47,8 +47,8 @@ func (s *TerminalRenderer) updateHashmap(newbuf *Buffer) {
 			s.newhash = make([]uint64, height)
 		}
 		for i := range height {
-			s.oldhash[i] = hash(&s.hasher, s.curbuf.Line(i))
-			s.newhash[i] = hash(&s.hasher, newbuf.Line(i))
+			s.oldhash[i] = hash(s.hasher, s.curbuf.Line(i))
+			s.newhash[i] = hash(s.hasher, newbuf.Line(i))
 		}
 	}
 
@@ -137,14 +137,14 @@ func (s *TerminalRenderer) scrollOldhash(n, top, bot int) {
 		copy(s.oldhash[top:], s.oldhash[top+n:top+n+size])
 		// Recalculate hashes for newly shifted-in lines
 		for i := bot; i > bot-n; i-- {
-			s.oldhash[i] = hash(&s.hasher, s.curbuf.Line(i))
+			s.oldhash[i] = hash(s.hasher, s.curbuf.Line(i))
 		}
 	} else {
 		// Move existing hashes down
 		copy(s.oldhash[top-n:], s.oldhash[top:top+size])
 		// Recalculate hashes for newly shifted-in lines
 		for i := top; i < top-n; i++ {
-			s.oldhash[i] = hash(&s.hasher, s.curbuf.Line(i))
+			s.oldhash[i] = hash(s.hasher, s.curbuf.Line(i))
 		}
 	}
 }


### PR DESCRIPTION
xxhash: ~13-15 GB/s throughput on modern CPUs
maphash: ~8-10 GB/s throughput

For small strings (like terminal cells): xxhash is ~20-30% faster.
xxhash has no allocation and consistent hash values across runs, which isn't the case for maphash so gets harder to test imho.