### PR TITLE
feat: character cells and line wrapping

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -196,48 +196,6 @@ func renderLine(buf io.StringWriter, l Line) {
 	}
 }
 
-// Lines represents a slice of lines.
-type Lines []Line
-
-// Height returns the height of the lines.
-func (ls Lines) Height() int {
-	return len(ls)
-}
-
-// Width returns the width of the widest line.
-func (ls Lines) Width() int {
-	maxWidth := 0
-	for _, l := range ls {
-		maxWidth = max(maxWidth, len(l))
-	}
-	return maxWidth
-}
-
-// String returns the string representation of the lines.
-func (ls Lines) String() string {
-	var buf strings.Builder
-	for i, l := range ls {
-		buf.WriteString(l.String())
-		if i < len(ls)-1 {
-			_ = buf.WriteByte('\n')
-		}
-	}
-	return buf.String()
-}
-
-// Render renders the lines to a styled string with all the required attributes
-// and styles.
-func (ls Lines) Render() string {
-	var buf strings.Builder
-	for i, l := range ls {
-		renderLine(&buf, l)
-		if i < len(ls)-1 {
-			_ = buf.WriteByte('\n')
-		}
-	}
-	return buf.String()
-}
-
 // Buffer represents a cell buffer that contains the contents of a screen.
 type Buffer struct {
 	// Lines is a slice of lines that make up the cells of the buffer.
@@ -263,13 +221,27 @@ func NewBuffer(width int, height int) *Buffer {
 
 // String returns the string representation of the buffer.
 func (b *Buffer) String() string {
-	return Lines(b.Lines).String()
+	var buf strings.Builder
+	for i, l := range b.Lines {
+		buf.WriteString(l.String())
+		if i < len(b.Lines)-1 {
+			_ = buf.WriteByte('\n')
+		}
+	}
+	return buf.String()
 }
 
 // Render renders the buffer to a styled string with all the required
 // attributes and styles.
 func (b *Buffer) Render() string {
-	return Lines(b.Lines).Render()
+	var buf strings.Builder
+	for i, l := range b.Lines {
+		renderLine(&buf, l)
+		if i < len(b.Lines)-1 {
+			_ = buf.WriteByte('\n')
+		}
+	}
+	return buf.String()
 }
 
 // Line returns a pointer to the line at the given y position.

--- a/chars.go
+++ b/chars.go
@@ -37,7 +37,7 @@ func DrawLines(scr Screen, area Rectangle, lines ...Line) {
 //
 // It ignores any newline characters, so the resulting slice will not contain
 // any line breaks. If you want to preserve line breaks, use [Lines] instead or
-// spilt the input string into lines first and then call [Characters] on each
+// split the input string into lines first and then call [Characters] on each
 // line.
 //
 // Any tab characters will be converted into 8 spaces. To convert tabs into a

--- a/chars.go
+++ b/chars.go
@@ -1,0 +1,331 @@
+package uv
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/clipperhouse/displaywidth"
+)
+
+// NBSP is the non-breaking space character. It is used to create padding
+// around text content without allowing the spaces to collapse or break onto a
+// new line.
+const NBSP = "\u00A0"
+
+// DrawLines draws the given lines to the buffer at the specified area.
+//
+// It assumes that the lines are already wrapped to fit within the width of the
+// area. Lines that exceed the height of the area will be truncated.
+//
+// Use [Wrapper] to wrap lines to a specific width before drawing them with
+// this function.
+func DrawLines(scr Screen, area Rectangle, lines ...Line) {
+	for y := 0; y < len(lines) && area.Min.Y+y < area.Max.Y; y++ {
+		line := lines[y]
+		for x := 0; x < len(line) && area.Min.X+x < area.Max.X; x++ {
+			cell := line[x]
+			if cell.IsZero() {
+				continue
+			}
+			scr.SetCell(area.Min.X+x, area.Min.Y+y, &cell)
+		}
+	}
+}
+
+// Characters returns a slice of [Cell]s representing the graphemes in the input string.
+//
+// It ignores any newline characters, so the resulting slice will not contain
+// any line breaks. If you want to preserve line breaks, use [Lines] instead or
+// spilt the input string into lines first and then call [Characters] on each
+// line.
+//
+// Any tab characters will be converted into 8 spaces. To convert tabs into a
+// different number of spaces, you can pre-process the input string using
+// [strings.ReplaceAll] or [bytes.ReplaceAll] before calling this function.
+func Characters[T ~string | ~[]byte](input T, wm WidthMethod) []Cell {
+	if len(input) == 0 {
+		return Line{}
+	}
+
+	const tabReplacement = "        " // 8 spaces
+	switch v := any(input).(type) {
+	case string:
+		input = any(strings.ReplaceAll(v, "\t", tabReplacement)).(T)
+	case []byte:
+		input = any(bytes.ReplaceAll(v, []byte("\t"), []byte(tabReplacement))).(T)
+	}
+
+	var cells []Cell
+	var grs displaywidth.Graphemes[T]
+	switch v := any(input).(type) {
+	case string:
+		grs = any(displaywidth.StringGraphemes(v)).(displaywidth.Graphemes[T])
+	case []byte:
+		grs = any(displaywidth.BytesGraphemes(v)).(displaywidth.Graphemes[T])
+	}
+
+	for grs.Next() {
+		gr := string(grs.Value())
+
+		var w int
+		if wm == ansi.GraphemeWidth {
+			w = grs.Width()
+		} else {
+			w = wm.StringWidth(gr)
+		}
+
+		if w == 0 {
+			// Skip any zero-width graphemes, such as standalone carriage
+			// returns or zero-width joiners. This is important to prevent
+			// zero-width graphemes from taking up space in the output, which
+			// can cause layout issues.
+			continue
+		}
+
+		cells = append(cells, Cell{
+			Content: gr,
+			Width:   w,
+		})
+		// Add padding cells for wide characters
+		for i := 1; i < w; i++ {
+			cells = append(cells, Cell{})
+		}
+	}
+
+	return cells
+}
+
+// Lines returns a slice of [Line]s representing the lines in the input string,
+// where each line is a slice of [Cell]s representing the graphemes in that
+// line.
+//
+// It treats newline characters as line breaks, so the resulting slice will
+// contain one [Line] per line in the input string. If you want to ignore line
+// breaks, use [Characters] instead.
+//
+// Any tab characters will be converted into 8 spaces. To convert tabs into a
+// different number of spaces, you can pre-process the input string using
+// [strings.ReplaceAll] or [bytes.ReplaceAll] before calling this function.
+func Lines[T ~string | ~[]byte](input T, wm WidthMethod) []Line {
+	if len(input) == 0 {
+		return nil
+	}
+
+	switch v := any(input).(type) {
+	case string:
+		input = any(strings.ReplaceAll(v, "\r\n", "\n")).(T)
+	case []byte:
+		input = any(bytes.ReplaceAll(v, []byte("\r\n"), []byte("\n"))).(T)
+	}
+
+	var inputLines []T
+	switch v := any(input).(type) {
+	case string:
+		inputLines = any(strings.Split(v, "\n")).([]T)
+	case []byte:
+		inputLines = any(bytes.Split(v, []byte("\n"))).([]T)
+	}
+
+	lines := make([]Line, len(inputLines))
+	for i, line := range inputLines {
+		lines[i] = Characters(line, wm)
+	}
+
+	return lines
+}
+
+// Wrapper represents [Line]s wrapper that can be used to wrap lines of [Cell]s
+// to a specified width.
+type Wrapper struct {
+	// Breakpoints is a slice of breakpoint graphemes that can be used to break
+	// lines. Spaces and dashes are always treated as a breakpoint, even if it
+	// is not included in this slice.
+	Breakpoints []string
+
+	// PreserveSpaces controls whether trailing whitespace is kept on wrapped
+	// lines. A whitespace cell is an empty cell with no attributes (see
+	// [isWhitespace]) or a NBSP cell with no attributes. When false (the
+	// default), trailing whitespace is trimmed from each wrapped line.
+	PreserveSpaces bool
+}
+
+// NewWrapper creates a new [Wrapper] with the specified breakpoints.
+func NewWrapper(breakpoints ...string) *Wrapper {
+	w := &Wrapper{
+		Breakpoints: breakpoints,
+	}
+	return w
+}
+
+// Wrap wraps the input lines to the specified width, returning a slice of
+// [Line]s representing the wrapped lines.
+//
+// It attempts to break lines at the specified breakpoints, but will fall back
+// to hard breaking if a single grapheme exceeds the width.
+func (lw *Wrapper) Wrap(lines []Line, width int) []Line {
+	if width <= 0 {
+		return lines
+	}
+
+	var result []Line
+
+	for _, line := range lines {
+		wrapped := wrapLine(line, width, lw.Breakpoints)
+		result = append(result, wrapped...)
+	}
+
+	if !lw.PreserveSpaces {
+		for i := range result {
+			result[i] = trimTrailingWhitespace(result[i])
+		}
+	}
+
+	return result
+}
+
+// wrapLine wraps a single line to the given width.
+func wrapLine(line Line, width int, extraBreakpoints []string) []Line {
+	if len(line) == 0 {
+		return []Line{{}}
+	}
+
+	// Check if line fits without wrapping
+	if len(line) <= width {
+		return []Line{line}
+	}
+
+	var result []Line
+	var currentLine Line
+
+	i := 0
+	for i < len(line) {
+		// Find the next word (sequence of cells until a breakpoint)
+		wordStart := i
+		wordEnd := i
+
+		// Consume the word (non-breakpoint characters)
+		for wordEnd < len(line) && !isBreakpoint(line[wordEnd], extraBreakpoints) {
+			wordEnd++
+		}
+
+		// Include trailing non-whitespace breakpoints in the word
+		// (dashes and extra breakpoints stay with the word)
+		for wordEnd < len(line) && isBreakpoint(line[wordEnd], extraBreakpoints) && !isWhitespace(line[wordEnd]) {
+			wordEnd++
+		}
+
+		word := line[wordStart:wordEnd]
+
+		// Check if word fits on current line
+		if len(currentLine)+len(word) <= width {
+			// Word fits, add it
+			currentLine = append(currentLine, word...)
+			i = wordEnd
+		} else if len(currentLine) == 0 {
+			// Word doesn't fit and line is empty - hard wrap
+			currentLine, i = hardWrapWord(word, width, currentLine, wordStart)
+			result, currentLine = flushIfNeeded(result, currentLine, width)
+		} else {
+			// Word doesn't fit - start new line
+			result = append(result, currentLine)
+			currentLine = nil
+			// Don't advance i - retry the word on the new line
+		}
+
+		// Handle trailing whitespace after the word
+		for i < len(line) && isWhitespace(line[i]) {
+			ws := line[i]
+			if len(currentLine)+1 <= width {
+				currentLine = append(currentLine, ws)
+				i++
+			} else {
+				// Whitespace doesn't fit - start new line
+				// Skip the whitespace that caused the break
+				i++
+				if i < len(line) {
+					result = append(result, currentLine)
+					currentLine = nil
+				}
+				break
+			}
+		}
+	}
+
+	// Add the last line
+	if len(currentLine) > 0 || len(result) == 0 {
+		result = append(result, currentLine)
+	}
+
+	return result
+}
+
+// hardWrapWord breaks a word that's too long to fit on a single line.
+func hardWrapWord(word Line, width int, currentLine Line, startIdx int) (Line, int) {
+	consumed := 0
+	for _, cell := range word {
+		// Empty cell (part of wide char) - include with previous
+		if cell.Width == 0 {
+			currentLine = append(currentLine, cell)
+			consumed++
+			continue
+		}
+
+		// Check if this cell (plus its placeholder cells) would fit
+		cellWidth := cell.Width
+		if len(currentLine)+cellWidth > width {
+			// Cell doesn't fit
+			if len(currentLine) == 0 && cellWidth > width {
+				// Single cell wider than width - include it anyway
+				currentLine = append(currentLine, cell)
+				consumed++
+				// Include placeholder cells
+				for j := consumed; j < len(word) && word[j].Width == 0; j++ {
+					currentLine = append(currentLine, word[j])
+					consumed++
+				}
+			}
+			break
+		}
+
+		currentLine = append(currentLine, cell)
+		consumed++
+	}
+
+	return currentLine, startIdx + consumed
+}
+
+// flushIfNeeded checks if current line is at capacity and needs flushing.
+func flushIfNeeded(result []Line, currentLine Line, width int) ([]Line, Line) {
+	if len(currentLine) >= width {
+		result = append(result, currentLine)
+		return result, nil
+	}
+	return result, currentLine
+}
+
+// isBreakpoint returns true if the cell is a breakpoint character.
+func isBreakpoint(cell Cell, extraBreakpoints []string) bool {
+	return isWhitespace(cell) || cell.Content == "-" ||
+		slices.Contains(extraBreakpoints, cell.Content)
+}
+
+var nbspCell = Cell{
+	Content: NBSP,
+	Width:   1,
+}
+
+// isWhitespace returns true if the cell is a space with no attributes.
+func isWhitespace(cell Cell) bool {
+	return cell.Equal(&EmptyCell) || cell.Equal(&nbspCell)
+}
+
+// trimTrailingWhitespace removes trailing whitespace cells from a line.
+func trimTrailingWhitespace(line Line) Line {
+	i := len(line)
+	for i > 0 && isWhitespace(line[i-1]) {
+		i--
+	}
+	return line[:i]
+}

--- a/chars_test.go
+++ b/chars_test.go
@@ -196,7 +196,7 @@ func TestWrap(t *testing.T) {
 			},
 		},
 		{
-			name:  "long string ",
+			name:  "long string",
 			input: "the quick brown foxxxxxxxxxxxxxxxx jumped over the lazy dog.",
 			width: 16,
 			want: []Line{

--- a/chars_test.go
+++ b/chars_test.go
@@ -184,7 +184,6 @@ func TestWrap(t *testing.T) {
 			width: 3,
 			want: []Line{
 				{},
-				{},
 			},
 		},
 		{

--- a/chars_test.go
+++ b/chars_test.go
@@ -1,0 +1,646 @@
+package uv
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestWrap(t *testing.T) {
+	c := func(s string, w int) Cell { return Cell{Content: s, Width: w} }
+	C := func(s string) Cell { return c(s, 1) }
+	W := func(s string) Cell { return c(s, 2) }
+	P := Cell{} // wide-char placeholder
+
+	t.Run("nil input", func(t *testing.T) {
+		result := wrap(t, nil, 10, "")
+		if result != nil {
+			t.Errorf("got %v, want nil", result)
+		}
+	})
+	t.Run("empty slice input", func(t *testing.T) {
+		result := wrap(t, []Line{}, 10, "")
+		if result != nil {
+			t.Errorf("got %v, want nil", result)
+		}
+	})
+	t.Run("empty line", func(t *testing.T) {
+		result := wrap(t, []Line{{}}, 10, "")
+		want := []Line{{}}
+		if !linesEqual(result, want) {
+			t.Errorf("got %v, want %v", result, want)
+		}
+	})
+
+	tests := []struct {
+		name   string
+		input  string
+		width  int
+		breaks string
+		want   []Line
+	}{
+		{
+			name:  "zero width",
+			input: "hello",
+			width: 0,
+			want:  []Line{{C("h"), C("e"), C("l"), C("l"), C("o")}},
+		},
+		{
+			name:  "negative width",
+			input: "hello",
+			width: -1,
+			want:  []Line{{C("h"), C("e"), C("l"), C("l"), C("o")}},
+		},
+		{
+			name:  "no wrap needed",
+			input: "hello",
+			width: 10,
+			want:  []Line{{C("h"), C("e"), C("l"), C("l"), C("o")}},
+		},
+		{
+			name:  "simple word wrap",
+			input: "hello world",
+			width: 6,
+			want: []Line{
+				{C("h"), C("e"), C("l"), C("l"), C("o")},
+				{C("w"), C("o"), C("r"), C("l"), C("d")},
+			},
+		},
+		{
+			name:  "multiple words",
+			input: "aa bb cc dd",
+			width: 5,
+			want: []Line{
+				{C("a"), C("a"), C(" "), C("b"), C("b")},
+				{C("c"), C("c"), C(" "), C("d"), C("d")},
+			},
+		},
+		{
+			name:  "hard wrap",
+			input: "abcdefghij",
+			width: 4,
+			want: []Line{
+				{C("a"), C("b"), C("c"), C("d")},
+				{C("e"), C("f"), C("g"), C("h")},
+				{C("i"), C("j")},
+			},
+		},
+		{
+			name:  "dash breakpoint",
+			input: "self-aware",
+			width: 6,
+			want: []Line{
+				{C("s"), C("e"), C("l"), C("f"), C("-")},
+				{C("a"), C("w"), C("a"), C("r"), C("e")},
+			},
+		},
+		{
+			name:   "extra breakpoints",
+			input:  "path/to/file",
+			width:  6,
+			breaks: "/",
+			want: []Line{
+				{C("p"), C("a"), C("t"), C("h"), C("/")},
+				{C("t"), C("o"), C("/")},
+				{C("f"), C("i"), C("l"), C("e")},
+			},
+		},
+		{
+			name:  "preserve line breaks",
+			input: "hello\nworld",
+			width: 10,
+			want: []Line{
+				{C("h"), C("e"), C("l"), C("l"), C("o")},
+				{C("w"), C("o"), C("r"), C("l"), C("d")},
+			},
+		},
+		{
+			name:  "preserve leading whitespace",
+			input: "  hello",
+			width: 10,
+			want:  []Line{{C(" "), C(" "), C("h"), C("e"), C("l"), C("l"), C("o")}},
+		},
+		{
+			name:  "trailing whitespace trimmed by default",
+			input: "hi   ",
+			width: 10,
+			want:  []Line{{C("h"), C("i")}},
+		},
+		{
+			name:  "wide characters fit",
+			input: "你好",
+			width: 4,
+			want:  []Line{{W("你"), P, W("好"), P}},
+		},
+		{
+			name:  "wide char at boundary",
+			input: "a你",
+			width: 2,
+			want: []Line{
+				{C("a")},
+				{W("你"), P},
+			},
+		},
+		{
+			name:  "tab character",
+			input: "hello\tworld",
+			width: 6,
+			want: []Line{
+				{C("h"), C("e"), C("l"), C("l"), C("o")},
+				{},
+				{C("w"), C("o"), C("r"), C("l"), C("d")},
+			},
+		},
+		{
+			name:  "mixed word wrap and hard wrap",
+			input: "hi abcdefgh",
+			width: 5,
+			want: []Line{
+				{C("h"), C("i")},
+				{C("a"), C("b"), C("c"), C("d"), C("e")},
+				{C("f"), C("g"), C("h")},
+			},
+		},
+		{
+			name:  "emoji",
+			input: "👋hi",
+			width: 4,
+			want:  []Line{{W("👋"), P, C("h"), C("i")}},
+		},
+		{
+			name:  "multiple dashes",
+			input: "a--b",
+			width: 3,
+			want: []Line{
+				{C("a"), C("-"), C("-")},
+				{C("b")},
+			},
+		},
+		{
+			name:  "only whitespace trimmed",
+			input: "     ",
+			width: 3,
+			want: []Line{
+				{},
+				{},
+			},
+		},
+		{
+			name:  "wide placeholder handling",
+			input: "你好世界",
+			width: 4,
+			want: []Line{
+				{W("你"), P, W("好"), P},
+				{W("世"), P, W("界"), P},
+			},
+		},
+		{
+			name:  "long string ",
+			input: "the quick brown foxxxxxxxxxxxxxxxx jumped over the lazy dog.",
+			width: 16,
+			want: []Line{
+				{C("t"), C("h"), C("e"), C(" "), C("q"), C("u"), C("i"), C("c"), C("k"), C(" "), C("b"), C("r"), C("o"), C("w"), C("n")},
+				{C("f"), C("o"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x"), C("x")},
+				{C("x"), C("x"), C(" "), C("j"), C("u"), C("m"), C("p"), C("e"), C("d"), C(" "), C("o"), C("v"), C("e"), C("r")},
+				{C("t"), C("h"), C("e"), C(" "), C("l"), C("a"), C("z"), C("y"), C(" "), C("d"), C("o"), C("g"), C(".")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := Lines(tt.input, ansi.GraphemeWidth)
+			result := wrap(t, lines, tt.width, tt.breaks)
+			if !linesEqual(result, tt.want) {
+				t.Errorf("got  \n%v\nwant \n%v", linesString(result), linesString(tt.want))
+			}
+		})
+	}
+}
+
+func TestLines_EmptyInput(t *testing.T) {
+	tests := []struct {
+		name string
+		wm   WidthMethod
+	}{
+		{"GraphemeWidth", ansi.GraphemeWidth},
+		{"WcWidth", ansi.WcWidth},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test empty string
+			result := Lines("", tt.wm)
+			if result != nil {
+				t.Errorf("Lines(\"\") = %v, want nil", result)
+			}
+
+			// Test empty []byte
+			result = Lines([]byte{}, tt.wm)
+			if result != nil {
+				t.Errorf("Lines([]byte{}) = %v, want nil", result)
+			}
+		})
+	}
+}
+
+func TestLines_SingleLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		wm    WidthMethod
+		want  []Line
+	}{
+		{
+			name:  "simple ASCII",
+			input: "hello",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "h", Width: 1},
+					{Content: "e", Width: 1},
+					{Content: "l", Width: 1},
+					{Content: "l", Width: 1},
+					{Content: "o", Width: 1},
+				},
+			},
+		},
+		{
+			name:  "wide characters (CJK)",
+			input: "你好",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "你", Width: 2},
+					{Content: "", Width: 0}, // placeholder
+					{Content: "好", Width: 2},
+					{Content: "", Width: 0}, // placeholder
+				},
+			},
+		},
+		{
+			name:  "emoji",
+			input: "👋🌍",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "👋", Width: 2},
+					{Content: "", Width: 0}, // placeholder
+					{Content: "🌍", Width: 2},
+					{Content: "", Width: 0}, // placeholder
+				},
+			},
+		},
+		{
+			name:  "emoji with ZWJ",
+			input: "👨‍👩‍👧",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "👨‍👩‍👧", Width: 2},
+					{Content: "", Width: 0}, // placeholder
+				},
+			},
+		},
+		{
+			name:  "multi codepoint emoji with wcwidth",
+			input: "🇸🇦",
+			wm:    ansi.WcWidth,
+			want: []Line{
+				{
+					{Content: "🇸🇦", Width: 1},
+				},
+			},
+		},
+		{
+			name:  "multi codepoint emoji with grapheme width",
+			input: "🇸🇦",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "🇸🇦", Width: 2},
+					{Content: "", Width: 0}, // placeholder
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Lines(tt.input, tt.wm)
+			if !linesEqual(result, tt.want) {
+				t.Errorf("Lines(%q) = %v, want %v", tt.input, result, tt.want)
+			}
+		})
+	}
+}
+
+func TestLines_MultipleLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		wm    WidthMethod
+		want  []Line
+	}{
+		{
+			name:  "two lines with LF",
+			input: "ab\ncd",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "a", Width: 1},
+					{Content: "b", Width: 1},
+				},
+				{
+					{Content: "c", Width: 1},
+					{Content: "d", Width: 1},
+				},
+			},
+		},
+		{
+			name:  "two lines with CRLF",
+			input: "ab\r\ncd",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "a", Width: 1},
+					{Content: "b", Width: 1},
+				},
+				{
+					{Content: "c", Width: 1},
+					{Content: "d", Width: 1},
+				},
+			},
+		},
+		{
+			name:  "trailing newline",
+			input: "ab\n",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "a", Width: 1},
+					{Content: "b", Width: 1},
+				},
+				{},
+			},
+		},
+		{
+			name:  "multiple empty lines",
+			input: "a\n\nb",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{
+					{Content: "a", Width: 1},
+				},
+				{},
+				{
+					{Content: "b", Width: 1},
+				},
+			},
+		},
+		{
+			name:  "only newlines",
+			input: "\n\n",
+			wm:    ansi.GraphemeWidth,
+			want: []Line{
+				{},
+				{},
+				{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Lines(tt.input, tt.wm)
+			if !linesEqual(result, tt.want) {
+				t.Errorf("Lines(%q) = %v, want %v", tt.input, result, tt.want)
+			}
+		})
+	}
+}
+
+func TestLines_CarriageReturn(t *testing.T) {
+	// Standalone \r should be skipped
+	input := "a\rb"
+	result := Lines(input, ansi.GraphemeWidth)
+	want := []Line{
+		{
+			{Content: "a", Width: 1},
+			{Content: "b", Width: 1},
+		},
+	}
+
+	if !linesEqual(result, want) {
+		t.Errorf("Lines(%q) = %v, want %v", input, result, want)
+	}
+}
+
+func TestLines_ByteSlice(t *testing.T) {
+	input := []byte("hello\nworld")
+	result := Lines(input, ansi.GraphemeWidth)
+	want := []Line{
+		{
+			{Content: "h", Width: 1},
+			{Content: "e", Width: 1},
+			{Content: "l", Width: 1},
+			{Content: "l", Width: 1},
+			{Content: "o", Width: 1},
+		},
+		{
+			{Content: "w", Width: 1},
+			{Content: "o", Width: 1},
+			{Content: "r", Width: 1},
+			{Content: "l", Width: 1},
+			{Content: "d", Width: 1},
+		},
+	}
+
+	if !linesEqual(result, want) {
+		t.Errorf("Lines(%q) = %v, want %v", input, result, want)
+	}
+}
+
+func TestLines_WcWidth(t *testing.T) {
+	// Test that WcWidth method is used correctly
+	// "你好" = 2 wide chars, each with width 2, so 4 cells total (2 content + 2 placeholder)
+	input := "你好"
+	result := Lines(input, ansi.WcWidth)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(result))
+	}
+
+	// 2 graphemes * 2 width = 4 cells (including placeholders)
+	if len(result[0]) != 4 {
+		t.Fatalf("expected 4 cells, got %d", len(result[0]))
+	}
+
+	// First cell should be content with width 2
+	if result[0][0].Width != 2 {
+		t.Errorf("cell[0].Width = %d, want 2", result[0][0].Width)
+	}
+	// Second cell should be placeholder
+	if result[0][1].Width != 0 {
+		t.Errorf("cell[1].Width = %d, want 0 (placeholder)", result[0][1].Width)
+	}
+}
+
+func TestLines_GraphemeClusters(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCells int // total cells including placeholders
+	}{
+		{
+			name:      "combining character",
+			input:     "e\u0301", // e + combining acute accent (´)
+			wantCells: 1,         // width 1, no placeholder
+		},
+		{
+			name:      "flag emoji",
+			input:     "🇺🇸",
+			wantCells: 2, // width 2, 1 content + 1 placeholder
+		},
+		{
+			name:      "skin tone modifier",
+			input:     "👋🏽",
+			wantCells: 2, // width 2, 1 content + 1 placeholder
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Lines(tt.input, ansi.GraphemeWidth)
+			if len(result) != 1 {
+				t.Fatalf("expected 1 line, got %d", len(result))
+			}
+			if len(result[0]) != tt.wantCells {
+				t.Errorf("got %d cells, want %d", len(result[0]), tt.wantCells)
+			}
+		})
+	}
+}
+
+func TestLines_LenEqualsDisplayWidth(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantWidth int
+	}{
+		{"ASCII", "hello", 5},
+		{"CJK", "你好", 4},
+		{"Mixed", "hi你", 4},
+		{"Emoji", "👋", 2},
+		{"ZWJ emoji", "👨‍👩‍👧", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Lines(tt.input, ansi.GraphemeWidth)
+			if len(result) != 1 {
+				t.Fatalf("expected 1 line, got %d", len(result))
+			}
+			if len(result[0]) != tt.wantWidth {
+				t.Errorf("len(line) = %d, want %d (display width)", len(result[0]), tt.wantWidth)
+			}
+		})
+	}
+}
+
+func wrap(t *testing.T, lines []Line, width int, extraBreakpoints string) []Line {
+	t.Helper()
+	var breakpoints []string
+	for _, r := range extraBreakpoints {
+		breakpoints = append(breakpoints, string(r))
+	}
+	lw := NewWrapper(breakpoints...)
+	return lw.Wrap(lines, width)
+}
+
+func TestWrapPreserveSpaces(t *testing.T) {
+	C := func(s string) Cell { return Cell{Content: s, Width: 1} }
+
+	tests := []struct {
+		name  string
+		input string
+		width int
+		want  []Line
+	}{
+		{
+			name:  "trailing spaces preserved",
+			input: "hi   ",
+			width: 10,
+			want:  []Line{{C("h"), C("i"), C(" "), C(" "), C(" ")}},
+		},
+		{
+			name:  "trailing space at wrap boundary preserved",
+			input: "hello world",
+			width: 6,
+			want: []Line{
+				{C("h"), C("e"), C("l"), C("l"), C("o"), C(" ")},
+				{C("w"), C("o"), C("r"), C("l"), C("d")},
+			},
+		},
+		{
+			name:  "only whitespace preserved",
+			input: "     ",
+			width: 3,
+			want: []Line{
+				{C(" "), C(" "), C(" ")},
+				{C(" ")},
+			},
+		},
+		{
+			name:  "mixed wrap trailing space preserved",
+			input: "hi abcdefgh",
+			width: 5,
+			want: []Line{
+				{C("h"), C("i"), C(" ")},
+				{C("a"), C("b"), C("c"), C("d"), C("e")},
+				{C("f"), C("g"), C("h")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := Lines(tt.input, ansi.GraphemeWidth)
+			lw := NewWrapper()
+			lw.PreserveSpaces = true
+			result := lw.Wrap(lines, tt.width)
+			if !linesEqual(result, tt.want) {
+				t.Errorf("got  %v\nwant %v", result, tt.want)
+			}
+		})
+	}
+}
+
+// linesEqual compares two [Line] slices for equality.
+func linesEqual(a, b []Line) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if len(a[i]) != len(b[i]) {
+			return false
+		}
+		if !reflect.DeepEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// linesString returns a string representation of a slice of [Line]s for debugging.
+func linesString(lines []Line) string {
+	var sb strings.Builder
+	for _, line := range lines {
+		sb.WriteString("[")
+		sb.WriteString(line.String())
+		sb.WriteString("]\n")
+	}
+	return sb.String()
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
-	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/image v0.32.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -18,8 +18,8 @@ github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+
 github.com/clipperhouse/displaywidth v0.9.0/go.mod h1:aCAAqTlh4GIVkhQnJpbL0T/WfcrJXHcj8C0yjYcjOZA=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
-github.com/clipperhouse/uax29/v2 v2.6.0 h1:z0cDbUV+aPASdFb2/ndFnS9ts/WNXgTNNGFoKXuhpos=
-github.com/clipperhouse/uax29/v2 v2.6.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
+github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/charmbracelet/x/termios v0.1.1
 	github.com/charmbracelet/x/windows v0.2.2
+	github.com/clipperhouse/displaywidth v0.9.0
 	github.com/clipperhouse/uax29/v2 v2.7.0
 	github.com/muesli/cancelreader v0.2.2
 	github.com/rivo/uniseg v0.4.7
@@ -16,10 +17,7 @@ require (
 	golang.org/x/sys v0.42.0
 )
 
-require (
-	github.com/clipperhouse/displaywidth v0.9.0 // indirect
-	github.com/clipperhouse/stringish v0.1.1 // indirect
-)
+require github.com/clipperhouse/stringish v0.1.1 // indirect
 
 require (
 	github.com/lucasb-eyer/go-colorful v1.3.0


### PR DESCRIPTION
This adds helper methods to construct []Cell and []Line slices out of
strings and []byte slices. This makes components much easier to build as
well as wrapping at word boundaries. The default behavior hardwraps
words that don't fit.