### PR TITLE
fix: auto-fix CBT use in JediTerm for GoLand/JetBrains' Run/Debug TTY

### DIFF
--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"hash/maphash"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/colorprofile"
@@ -1584,6 +1585,9 @@ func xtermCaps(termtype string) (v capabilities) {
 			v &^= capHPA
 			v &^= capCHT
 			v &^= capREP
+			if isJediTerm() {
+				v &^= capCBT
+			}
 		}
 	case "alacritty":
 		v = allCaps
@@ -1598,4 +1602,29 @@ func xtermCaps(termtype string) (v capabilities) {
 	}
 
 	return v
+}
+
+// isJediTerm returns true when running inside JetBrains' JediTerm terminal
+// emulator (GoLand, IntelliJ, etc.). JediTerm mishandles CBT escape
+// sequences that ultraviolet emits under normal TERM values.
+//
+// Detection layers (checked in order):
+//  1. TERMINAL_EMULATOR == "JetBrains-JediTerm" — all platforms, Terminal tool window
+//  2. __CFBundleIdentifier starts with "com.jetbrains." — macOS, "Emulate terminal" Run/Debug
+//  3. XPC_SERVICE_NAME contains "com.jetbrains." — macOS, "Emulate terminal" Run/Debug
+//  4. TOOLBOX_VERSION is non-empty — all platforms, all contexts (JetBrains Toolbox installs only)
+func isJediTerm() bool {
+	if os.Getenv("TERMINAL_EMULATOR") == "JetBrains-JediTerm" {
+		return true
+	}
+	if strings.HasPrefix(os.Getenv("__CFBundleIdentifier"), "com.jetbrains.") {
+		return true
+	}
+	if strings.Contains(os.Getenv("XPC_SERVICE_NAME"), "com.jetbrains.") {
+		return true
+	}
+	if os.Getenv("TOOLBOX_VERSION") != "" {
+		return true
+	}
+	return false
 }

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -1326,6 +1326,92 @@ func TestRendererEnterExitAltScreen(t *testing.T) {
 	}
 }
 
+func TestIsJediTerm(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "detected via TERMINAL_EMULATOR",
+			env:  map[string]string{"TERMINAL_EMULATOR": "JetBrains-JediTerm"},
+			want: true,
+		},
+		{
+			name: "detected via __CFBundleIdentifier",
+			env:  map[string]string{"__CFBundleIdentifier": "com.jetbrains.goland"},
+			want: true,
+		},
+		{
+			name: "detected via XPC_SERVICE_NAME",
+			env:  map[string]string{"XPC_SERVICE_NAME": "application.com.jetbrains.goland.12345"},
+			want: true,
+		},
+		{
+			name: "not detected when env is empty",
+			env:  map[string]string{},
+			want: false,
+		},
+		{
+			name: "detected via TOOLBOX_VERSION",
+			env:  map[string]string{"TOOLBOX_VERSION": "2.6.2.40984"},
+			want: true,
+		},
+		{
+			name: "not detected for other terminals",
+			env:  map[string]string{"TERMINAL_EMULATOR": "iTerm2"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear relevant env vars (t.Setenv handles save/restore)
+			keys := []string{"TERMINAL_EMULATOR", "__CFBundleIdentifier", "XPC_SERVICE_NAME", "TOOLBOX_VERSION"}
+			for _, k := range keys {
+				t.Setenv(k, "")
+			}
+			// Set test env vars
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			if got := isJediTerm(); got != tt.want {
+				t.Errorf("isJediTerm() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestXtermCapsJediTermDisablesCBT(t *testing.T) {
+	// Save and clear env
+	keys := []string{"TERMINAL_EMULATOR", "__CFBundleIdentifier", "XPC_SERVICE_NAME", "TOOLBOX_VERSION"}
+	for _, k := range keys {
+		t.Setenv(k, "")
+	}
+
+	// Without JediTerm, xterm-256color should have CBT
+	caps := xtermCaps("xterm-256color")
+	if !caps.Contains(capCBT) {
+		t.Error("xterm-256color should have capCBT when not in JediTerm")
+	}
+
+	// With JediTerm, xterm-256color should NOT have CBT
+	t.Setenv("TERMINAL_EMULATOR", "JetBrains-JediTerm")
+	caps = xtermCaps("xterm-256color")
+	if caps.Contains(capCBT) {
+		t.Error("xterm-256color should NOT have capCBT when in JediTerm")
+	}
+
+	// Other caps should still be present (VPA, CHA, etc.)
+	if !caps.Contains(capVPA) {
+		t.Error("xterm-256color in JediTerm should still have capVPA")
+	}
+	if !caps.Contains(capCHA) {
+		t.Error("xterm-256color in JediTerm should still have capCHA")
+	}
+}
+
 // Helper type for testing logger
 type testLogger struct {
 	buf *bytes.Buffer


### PR DESCRIPTION
## Summary

Automatically detect [JediTerm](https://github.com/JetBrains/jediterm) (GoLand/IntelliJ terminal) and disable Cursor Backward Tab _(CBT)_ to prevent invalid rendering — no action required from application developers.

## Motivation

**JetBrains GoLand** _and all IntelliJ-based IDEs_ use [JediTerm](https://github.com/JetBrains/jediterm) as their built-in terminal emulator. JediTerm reports `TERM=xterm-256color` but does not correctly handle **Cursor Backward Tab _(CBT)_**, which can result in invalid rendering when ultraviolet's differential renderer emits it.

This **may seem like a niche edge case**; however **a large number of Bubble Tea apps will be run inside GoLand** and may hit this bug, **including when Delve debugging** as [GoLand is the 2nd most popular IDE for Go](https://go.dev/blog/survey2024-h2-results#:~:text=GoLand).

The rendering breaks in ways that are **very difficult to diagnose**. In my case, it took **roughly a week of investigation** as I kept assuming the bug was in my own code, not in terminal capability handling. I would hate for other developers to hit the same wall and come away frustrated with the Bubble Tea ecosystem when the fix is straightforward.

Without this fix, **every Go developer using GoLand** who builds a Bubble Tea app with view transitions would need to independently discover the issue, diagnose it, and manually work around it. Auto-detection eliminates this entirely.

## How it works

JediTerm detection uses four environment checks to cover both the built-in terminal, [Run/Debug configurations](https://www.jetbrains.com/help/go/run-debug-configuration.html) where `TERMINAL_EMULATOR` is not propagated, and JetBrains Toolbox installs:

| # | Check | Platforms | Context |
|---|-------|-----------|---------|
| 1 | `TERMINAL_EMULATOR == "JetBrains-JediTerm"` | All | Terminal tool window |
| 2 | `__CFBundleIdentifier` starts with `"com.jetbrains."` | macOS | Run/Debug TTY|
| 3 | `XPC_SERVICE_NAME` contains `"com.jetbrains."` | macOS | Run/Debug TTY |
| 4 | `TOOLBOX_VERSION` is non-empty | All | All Toolbox installs |

Check 1 covers the Terminal tool window on all platforms. Checks 2–3 cover the "Emulate terminal in output console" Run/Debug path on macOS. Check 4 covers all contexts on all platforms for users who installed their IDE via JetBrains Toolbox (the default/recommended install method).

When detected, `capCBT` is removed from the xterm default capability set in `xtermCaps()`. No application code changes are needed — existing Bubble Tea apps will just work correctly in GoLand.

I have filled these which could make the problem a non-issue:

- [Add CBT (Cursor Backward Tabulation) issue #328](https://github.com/JetBrains/jediterm/issues/328) that would make this change unnecessry, but Jedit has `7` open PRs some open since `2021`, and `43` open issues so I do not have high confidence they will address this anytime soon, if ever.

- [YouTrack issue G0-20196](https://youtrack.jetbrains.com/issue/GO-20196/Set-TERMINALEMULATOR-when-Emulate-terminal-in-output-console-is-enabled-in-Run-Debug-configurations) requesting that JetBrains set `TERMINAL_EMULATOR=JetBrains-JediTerm` in the _"Emulate terminal"_ Run/Debug code path, which would make checks 2–4 unnecessary but check 1 would still be necessary.

And these which would allow end-users of apps to fix broken terminal output for any edge-case terminals that ultraviolet does not currently detect:

- [ultraviolet #100](https://github.com/charmbracelet/ultraviolet/pull/100) — `DisableCaps` API for manually disabling capabilities

- [bubbletea #1641](https://github.com/charmbracelet/bubbletea/pull/1641) — `WithoutCaps` option at the Bubble Tea level

## Reproduction

A minimal standalone app that reproduces the rendering issue is available as a Gist: [jediterm-bug](https://gist.github.com/mikeschinkel/f1df4157816374675845658e490ea507). Run it inside GoLand's Run/Debug terminal (or [ForceTerm](https://github.com/sebkur/forceterm)) and press space to toggle between the two layouts — the second layout will render incorrectly.

_**Note:**_ There is a standalone JediTerm you can use for testing named [ForceTerm](https://github.com/sebkur/forceterm) if you prefer not to install GoLand.

## Changes

- **`terminal_renderer.go`** — Add `isJediTerm()` function with four environment checks. In `xtermCaps()`, disable `capCBT` in the xterm default case when JediTerm is detected.
- **`terminal_renderer_test.go`** — Tests for `isJediTerm()` detection via all four environment variables, and verification that `xtermCaps()` strips CBT when in JediTerm while preserving other capabilities.

## Test plan

- [x] `TestIsJediTerm` — verifies detection via `TERMINAL_EMULATOR`, `__CFBundleIdentifier`, `XPC_SERVICE_NAME`, and `TOOLBOX_VERSION`; verifies non-detection for empty env and other terminals
- [x] `TestXtermCapsJediTermDisablesCBT` — verifies CBT is present for normal xterm, absent for JediTerm xterm, and other caps (VPA, CHA) are preserved
- [x] Manual testing with JediTerm (GoLand terminal) confirms rendering issue is resolved
- [x] All existing tests pass
