### PR TITLE
fix: correct wide character (CJK) rendering corruption

### DIFF
--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -450,6 +450,18 @@ func (s *TerminalRenderer) move(newbuf *RenderBuffer, x, y int) {
 	s.moveCursor(newbuf, x, y, true) // Overwrite cells if possible
 }
 
+// lineHasWideChars reports whether the line contains any wide (multi-column)
+// characters within the range [start, end].
+func lineHasWideChars(line Line, start, end int) bool {
+	for i := start; i <= end && i < len(line); i++ {
+		c := line.At(i)
+		if c != nil && c.Width > 1 {
+			return true
+		}
+	}
+	return false
+}
+
 // cellEqual returns whether the two cells are equal. A nil cell is considered
 // a [EmptyCell].
 func cellEqual(a, b *Cell) bool {
@@ -789,6 +801,16 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	oldLine := s.curbuf.Line(y)
 	newLine := newbuf.Line(y)
 
+	// When wide characters are present, many column-based optimizations
+	// (ICH, DCH, ECH, EL1, REP, and the putRange same-cell skip) can
+	// break rendering by operating on individual columns rather than full
+	// character cells. Use a simple redraw path instead.
+	if lineHasWideChars(newLine, 0, newbuf.Width()-1) ||
+		lineHasWideChars(oldLine, 0, newbuf.Width()-1) {
+		s.transformLineWide(newbuf, y, oldLine, newLine)
+		return
+	}
+
 	// Find the first changed cell in the line
 	blank := newLine.At(0)
 
@@ -971,6 +993,77 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	}
 
 	// Update the old line with the new line
+	if firstCell < len(oldLine) && firstCell < len(newLine) {
+		copy(oldLine[firstCell:], newLine[firstCell:])
+	} else {
+		copy(oldLine, newLine)
+	}
+}
+
+// transformLineWide is the wide-character-safe path for transformLine. It
+// bypasses all column-shifting optimizations (ICH, DCH, ECH, EL1, REP) that
+// can corrupt multi-column characters, and instead directly emits every
+// changed cell.
+func (s *TerminalRenderer) transformLineWide(newbuf *RenderBuffer, y int, oldLine, newLine Line) {
+	w := newbuf.Width()
+
+	// Find the first differing cell. If it lands on a zero-width
+	// placeholder, back up to the actual wide character so we re-emit it
+	// completely.
+	firstCell := 0
+	for firstCell < w && cellEqual(oldLine.At(firstCell), newLine.At(firstCell)) {
+		firstCell++
+	}
+	if firstCell >= w {
+		return
+	}
+	for firstCell > 0 {
+		c := newLine.At(firstCell)
+		if c != nil && c.IsZero() {
+			firstCell--
+		} else {
+			break
+		}
+	}
+
+	// Find the last differing cell. If it landed on a wide char, extend
+	// to include its placeholder.
+	lastCell := w - 1
+	for lastCell > firstCell && cellEqual(oldLine.At(lastCell), newLine.At(lastCell)) {
+		lastCell--
+	}
+	if lastCell < w-1 {
+		c := newLine.At(lastCell)
+		if c != nil && c.Width > 1 {
+			lastCell += c.Width - 1
+			if lastCell >= w {
+				lastCell = w - 1
+			}
+		}
+	}
+
+	// Move to the first changed position and emit all cells through the
+	// last changed position.
+	s.move(newbuf, firstCell, y)
+	for i := firstCell; i <= lastCell; i++ {
+		s.putCell(newbuf, newLine.At(i))
+	}
+
+	// Clear any residual content after lastCell if the old line extended
+	// further (e.g. content was deleted or shortened).
+	blank := &Cell{Content: " ", Width: 1}
+	needClear := false
+	for j := lastCell + 1; j < w; j++ {
+		if !cellEqual(oldLine.At(j), newLine.At(j)) {
+			needClear = true
+			break
+		}
+	}
+	if needClear {
+		s.clearToEnd(newbuf, blank, true)
+	}
+
+	// Update curbuf to match newbuf.
 	if firstCell < len(oldLine) && firstCell < len(newLine) {
 		copy(oldLine[firstCell:], newLine[firstCell:])
 	} else {
@@ -1399,7 +1492,17 @@ func relativeCursorMove(s *TerminalRenderer, newbuf *RenderBuffer, fx, fy, tx, t
 			}
 
 			// If we have no attribute and style changes, overwrite is cheaper.
+
+			// Disable overwrite for lines containing wide characters:
+			// the loop emits spaces for zero-width placeholders, which
+			// destroys the preceding wide character on the terminal.
 			var ovw string
+			if overwrite && ty >= 0 && newbuf != nil {
+				line := newbuf.Line(ty)
+				if lineHasWideChars(line, 0, len(line)-1) {
+					overwrite = false
+				}
+			}
 			if overwrite && ty >= 0 {
 				for i := 0; i < n; i++ {
 					cell := newbuf.CellAt(fx+i, ty)

--- a/terminal_renderer_wide_test.go
+++ b/terminal_renderer_wide_test.go
@@ -1,0 +1,398 @@
+package uv
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTransformLineWideCJKShift(t *testing.T) {
+	cases := []struct {
+		name   string
+		frames []string
+		width  int
+		check  []rune
+	}{
+		{
+			name:   "shift CJK right by 1",
+			frames: []string{"你好世界", "a你好世界"},
+			width:  20,
+			check:  []rune{'你', '好', '世', '界'},
+		},
+		{
+			name:   "shift CJK right by 2",
+			frames: []string{"你好世界", "ab你好世界"},
+			width:  20,
+			check:  []rune{'你', '好', '世', '界'},
+		},
+		{
+			name:   "shift CJK left by 1",
+			frames: []string{"a你好世界", "你好世界"},
+			width:  20,
+			check:  []rune{'你', '好', '世', '界'},
+		},
+		{
+			name:   "shift CJK left by 2",
+			frames: []string{"ab你好世界", "你好世界"},
+			width:  20,
+			check:  []rune{'你', '好', '世', '界'},
+		},
+		{
+			name:   "shift back and forth",
+			frames: []string{"你好世界", "a你好世界", "你好世界"},
+			width:  20,
+			check:  []rune{'你', '好', '世', '界'},
+		},
+		{
+			name:   "insert in mixed ASCII/CJK",
+			frames: []string{"abc你好def世界ghi", "abcd你好def世界ghi"},
+			width:  30,
+			check:  []rune{'你', '好', '世', '界'},
+		},
+		{
+			name:   "delete in mixed ASCII/CJK",
+			frames: []string{"abcd你好def世界ghi", "abc你好def世界ghi"},
+			width:  30,
+			check:  []rune{'你', '好', '世', '界'},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			scr := NewScreenBuffer(tc.width, 3)
+			r := NewTerminalRenderer(&buf, []string{
+				"TERM=xterm-256color",
+				"COLORTERM=truecolor",
+			})
+			area := Rect(0, 0, tc.width, 3)
+
+			for i, text := range tc.frames {
+				buf.Reset()
+				ss := NewStyledString(text)
+				ss.Draw(&scr, area)
+				r.Render(scr.RenderBuffer)
+				if err := r.Flush(); err != nil {
+					t.Fatalf("frame %d: flush failed: %v", i, err)
+				}
+
+				if i == 0 {
+					continue
+				}
+
+				output := buf.String()
+				for _, ch := range tc.check {
+					if !strings.Contains(output, string(ch)) {
+						t.Errorf("frame %d (%q): wide character %q missing from incremental output %q",
+							i, text, string(ch), output)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestTransformLineWideBufferState verifies that after each render the
+// internal curbuf exactly matches newbuf for every cell. This catches bugs
+// where ANSI output is wrong but the buffer tracking is also wrong
+// (hiding the mismatch from simpler output-only tests).
+func TestTransformLineWideBufferState(t *testing.T) {
+	width, height := 40, 3
+
+	frames := []string{
+		"  你好世界",
+		"  a你好世界",
+		"  你好世界",
+		"Hello 你好世界 world",
+		"Hello 你好 world",
+		"Hello 你好世界测试 world",
+		"  Hello 你好世界测试 world",
+		"Hello 你好世界测试 world",
+		strings.Repeat("你", width/2),
+		strings.Repeat("a你", width/3),
+		"",
+		"你好",
+		"ab你好cd世界ef",
+		"你好cd世界ef",
+		"ab你好世界ef",
+	}
+
+	var buf bytes.Buffer
+	scr := NewScreenBuffer(width, height)
+	r := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+	area := Rect(0, 0, width, height)
+
+	for i, text := range frames {
+		buf.Reset()
+		ss := NewStyledString(text)
+		scr.Fill(nil)
+		ss.Draw(&scr, area)
+		r.Render(scr.RenderBuffer)
+		if err := r.Flush(); err != nil {
+			t.Fatalf("frame %d: flush failed: %v", i, err)
+		}
+
+		for y := 0; y < height; y++ {
+			curLine := r.curbuf.Line(y)
+			newLine := scr.RenderBuffer.Line(y)
+			for x := 0; x < width; x++ {
+				got := curLine.At(x)
+				want := newLine.At(x)
+				if !cellEqual(got, want) {
+					gotStr := "<nil>"
+					wantStr := "<nil>"
+					if got != nil {
+						gotStr = got.Content
+					}
+					if want != nil {
+						wantStr = want.Content
+					}
+					t.Errorf("frame %d (%q): cell mismatch at (%d,%d): curbuf=%q want=%q",
+						i, text, x, y, gotStr, wantStr)
+				}
+			}
+		}
+	}
+}
+
+// TestTransformLineWideRepeatedChars tests lines where the same wide
+// character repeats (would trigger ECH/REP in emitRange for narrow chars).
+// Verifies buffer state correctness.
+func TestTransformLineWideRepeatedChars(t *testing.T) {
+	var buf bytes.Buffer
+	width, height := 30, 1
+	scr := NewScreenBuffer(width, height)
+	r := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+	area := Rect(0, 0, width, height)
+
+	frames := []string{
+		"你你你你你",
+		"好你你你你你",
+		"你你你你你",
+		"你你好你你",
+	}
+
+	for i, text := range frames {
+		buf.Reset()
+		ss := NewStyledString(text)
+		scr.Fill(nil)
+		ss.Draw(&scr, area)
+		r.Render(scr.RenderBuffer)
+		if err := r.Flush(); err != nil {
+			t.Fatalf("frame %d: flush failed: %v", i, err)
+		}
+
+		for y := 0; y < height; y++ {
+			curLine := r.curbuf.Line(y)
+			newLine := scr.RenderBuffer.Line(y)
+			for x := 0; x < width; x++ {
+				got := curLine.At(x)
+				want := newLine.At(x)
+				if !cellEqual(got, want) {
+					gotStr, wantStr := "<nil>", "<nil>"
+					if got != nil {
+						gotStr = got.Content
+					}
+					if want != nil {
+						wantStr = want.Content
+					}
+					t.Errorf("frame %d (%q): cell (%d,%d): got=%q want=%q",
+						i, text, x, y, gotStr, wantStr)
+				}
+			}
+		}
+	}
+}
+
+// TestTransformLineWideLeadingBlanks tests the EL1 (EraseLineLeft) code
+// path with wide characters.
+func TestTransformLineWideLeadingBlanks(t *testing.T) {
+	var buf bytes.Buffer
+	width, height := 30, 1
+	scr := NewScreenBuffer(width, height)
+	r := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+	area := Rect(0, 0, width, height)
+
+	frames := []string{
+		"你好世界",
+		"    你好世界",
+		"        你好世界",
+		"你好世界",
+		"  你好世界  ",
+	}
+
+	for i, text := range frames {
+		buf.Reset()
+		ss := NewStyledString(text)
+		scr.Fill(nil)
+		ss.Draw(&scr, area)
+		r.Render(scr.RenderBuffer)
+		if err := r.Flush(); err != nil {
+			t.Fatalf("frame %d: flush failed: %v", i, err)
+		}
+
+		for y := 0; y < height; y++ {
+			curLine := r.curbuf.Line(y)
+			newLine := scr.RenderBuffer.Line(y)
+			for x := 0; x < width; x++ {
+				got := curLine.At(x)
+				want := newLine.At(x)
+				if !cellEqual(got, want) {
+					gotStr, wantStr := "<nil>", "<nil>"
+					if got != nil {
+						gotStr = got.Content
+					}
+					if want != nil {
+						wantStr = want.Content
+					}
+					t.Errorf("frame %d (%q): cell (%d,%d): got=%q want=%q",
+						i, text, x, y, gotStr, wantStr)
+				}
+			}
+		}
+	}
+}
+
+// TestTransformLineWideMultiLine exercises cursor movement across multiple
+// lines containing wide characters. The relativeCursorMove overwrite
+// optimization must not emit spaces for zero-width placeholders.
+func TestTransformLineWideMultiLine(t *testing.T) {
+	width, height := 30, 5
+
+	// Frame pairs: each inner slice is drawn as consecutive frames.
+	// Line 0 changes between frames; lines 1-2 have wide chars that
+	// the cursor must traverse without corruption.
+	type frame struct {
+		lines []string
+	}
+	scenarios := []struct {
+		name   string
+		frames []frame
+	}{
+		{
+			name: "change line 0 with CJK on lines below",
+			frames: []frame{
+				{lines: []string{"hello world", "你好世界", "测试数据"}},
+				{lines: []string{"HELLO WORLD", "你好世界", "测试数据"}},
+				{lines: []string{"hello world", "你好世界", "测试数据"}},
+			},
+		},
+		{
+			name: "change last line with CJK on lines above",
+			frames: []frame{
+				{lines: []string{"你好世界", "测试数据", "aaa"}},
+				{lines: []string{"你好世界", "测试数据", "bbb"}},
+			},
+		},
+		{
+			name: "change multiple lines with wide chars",
+			frames: []frame{
+				{lines: []string{"AAAA", "你好世界", "BBBB", "测试数据", "CCCC"}},
+				{lines: []string{"aaaa", "你好世界X", "bbbb", "测试X数据", "cccc"}},
+			},
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			scr := NewScreenBuffer(width, height)
+			r := NewTerminalRenderer(&buf, []string{
+				"TERM=xterm-256color",
+				"COLORTERM=truecolor",
+			})
+
+			for fi, fr := range sc.frames {
+				buf.Reset()
+				scr.Fill(nil)
+				for li, line := range fr.lines {
+					if li >= height {
+						break
+					}
+					area := Rect(0, li, width, li+1)
+					ss := NewStyledString(line)
+					ss.Draw(&scr, area)
+				}
+				r.Render(scr.RenderBuffer)
+				if err := r.Flush(); err != nil {
+					t.Fatalf("frame %d: flush failed: %v", fi, err)
+				}
+
+				for y := 0; y < height; y++ {
+					curLine := r.curbuf.Line(y)
+					newLine := scr.RenderBuffer.Line(y)
+					for x := 0; x < width; x++ {
+						got := curLine.At(x)
+						want := newLine.At(x)
+						if !cellEqual(got, want) {
+							gotStr, wantStr := "<nil>", "<nil>"
+							if got != nil {
+								gotStr = got.Content
+							}
+							if want != nil {
+								wantStr = want.Content
+							}
+							t.Errorf("frame %d: cell (%d,%d): got=%q want=%q",
+								fi, x, y, gotStr, wantStr)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTransformLineWideCJKStreaming(t *testing.T) {
+	var buf bytes.Buffer
+	scr := NewScreenBuffer(30, 3)
+	r := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+	area := Rect(0, 0, 30, 3)
+
+	texts := []string{
+		"你",
+		"你好",
+		"你好世",
+		"你好世界",
+		"你好世界，",
+		"你好世界，这",
+		"你好世界，这是",
+		"你好世界，这是一",
+		"你好世界，这是一个",
+		"你好世界，这是一个测",
+		"你好世界，这是一个测试",
+	}
+
+	for i, text := range texts {
+		buf.Reset()
+		ss := NewStyledString(text)
+		ss.Draw(&scr, area)
+		r.Render(scr.RenderBuffer)
+		if err := r.Flush(); err != nil {
+			t.Fatalf("step %d: flush failed: %v", i, err)
+		}
+
+		if i == 0 {
+			continue
+		}
+
+		output := buf.String()
+		runes := []rune(text)
+		lastChar := string(runes[len(runes)-1])
+		if !strings.Contains(output, lastChar) {
+			t.Errorf("step %d (%q): new character %q missing from incremental output %q",
+				i, text, lastChar, output)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Wide characters (CJK, emoji, etc.) intermittently disappear or show only background color during streaming terminal updates (e.g. when an LLM streams CJK content character-by-character in a Bubble Tea TUI). This is caused by two independent bugs in the rendering pipeline.

## Root Causes

### 1. `transformLine` optimization paths corrupt wide characters

`transformLine()` has multiple column-based optimizations (ICH, DCH, ECH, REP, EL1, `putRange` same-cell skip) that assume each cell occupies exactly 1 terminal column. Wide characters occupy 2 columns: column N holds the real cell (`Width=2`), column N+1 holds a zero-width placeholder (`Width=0, IsZero=true`). These optimizations shift, erase, or skip individual columns, splitting wide characters and producing corrupted output.

**Fix**: When either old or new line contains wide chars, `transformLine` delegates to a new `transformLineWide` function that bypasses all optimizations and uses the simplest possible approach — find the diff range, emit every cell via `putCell`, optionally clear to end of line, and copy newbuf to curbuf.

### 2. `relativeCursorMove` overwrite optimization corrupts wide characters

When moving the cursor rightward, `relativeCursorMove` can "overwrite" cells from `newbuf` instead of emitting escape sequences (e.g., writing `hello` is shorter than `\x1b[5C`). The overwrite loop handles `Width == 0` cells (zero-width placeholders) by writing a space, which destroys the wide character on the terminal. Since `curbuf` is not updated during cursor movement, the damage is never repaired on subsequent renders.

**Fix**: Before the overwrite loops, check if the target line has any wide characters. If so, disable overwrite and fall back to escape sequences (`CursorForward`).

## Approach

This fix is deliberately conservative — it disables optimizations for lines containing wide characters rather than trying to make each optimization wide-char-aware. This is simpler, easier to verify, and avoids introducing subtle edge cases into the optimization paths.

## Testing

Added 6 test functions covering:
- CJK character shift left/right by 1 and 2 columns
- 15-frame streaming buffer state verification
- Repeated wide characters
- Leading blanks with wide characters
- Multi-line cursor movement across wide-char lines
- Character-by-character streaming simulation

All existing tests continue to pass.