### PR TITLE
perf: keep render buffers live across draws

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -687,6 +687,12 @@ func (b *RenderBuffer) Touch(x, y int) {
 	b.TouchLine(x, y, 0)
 }
 
+func (b *RenderBuffer) touchArea(area Rectangle) {
+	for y := area.Min.Y; y < area.Max.Y; y++ {
+		b.TouchLine(area.Min.X, y, area.Max.X-area.Min.X)
+	}
+}
+
 // TouchedLines returns the number of touched lines in the buffer.
 func (b *RenderBuffer) TouchedLines() int {
 	if b.Touched == nil {
@@ -712,6 +718,28 @@ func (b *RenderBuffer) SetCell(x, y int, c *Cell) {
 		b.TouchLine(x, y, width)
 	}
 	b.Buffer.SetCell(x, y, c)
+}
+
+// Fill fills the entire render buffer with the given cell and marks it dirty.
+func (b *RenderBuffer) Fill(c *Cell) {
+	b.FillArea(c, b.Bounds())
+}
+
+// FillArea fills the given area and marks it dirty.
+func (b *RenderBuffer) FillArea(c *Cell, area Rectangle) {
+	b.Buffer.FillArea(c, area)
+	b.touchArea(area)
+}
+
+// Clear clears the entire render buffer and marks it dirty.
+func (b *RenderBuffer) Clear() {
+	b.ClearArea(b.Bounds())
+}
+
+// ClearArea clears the given area and marks it dirty.
+func (b *RenderBuffer) ClearArea(area Rectangle) {
+	b.Buffer.ClearArea(area)
+	b.touchArea(area)
 }
 
 // InsertLine inserts n lines at the given line position, with the given

--- a/styled.go
+++ b/styled.go
@@ -48,17 +48,36 @@ func (s *StyledString) Lines(m ansi.Method) []Line {
 // Draw renders the styled string to the given buffer at the
 // specified area.
 func (s *StyledString) Draw(buf Screen, area Rectangle) {
-	// Clear the area before drawing.
-	for y := area.Min.Y; y < area.Max.Y; y++ {
-		for x := area.Min.X; x < area.Max.X; x++ {
-			buf.SetCell(x, y, nil)
-		}
-	}
+	clearScreenArea(buf, area)
 	str := s.Text
 	// We need to normalize newlines "\n" to "\r\n" to emulate a raw terminal
 	// output.
-	str = strings.ReplaceAll(str, "\r\n", "\n")
+	if strings.Contains(str, "\r\n") {
+		str = strings.ReplaceAll(str, "\r\n", "\n")
+	}
 	printString(buf, buf.WidthMethod(), area.Min.X, area.Min.Y, area, str, !s.Wrap, s.Tail)
+}
+
+func clearScreenArea(scr Screen, area Rectangle) {
+	if c, ok := scr.(interface {
+		ClearArea(area Rectangle)
+	}); ok {
+		c.ClearArea(area)
+		return
+	}
+
+	if f, ok := scr.(interface {
+		FillArea(cell *Cell, area Rectangle)
+	}); ok {
+		f.FillArea(nil, area)
+		return
+	}
+
+	for y := area.Min.Y; y < area.Max.Y; y++ {
+		for x := area.Min.X; x < area.Max.X; x++ {
+			scr.SetCell(x, y, nil)
+		}
+	}
 }
 
 // Height returns the number of lines in the styled string. This is the number
@@ -109,8 +128,10 @@ func printString[T []byte | string](
 	defer ansi.PutParser(p)
 
 	var tailc Cell
+	tailWidth := 0
 	if truncate && len(tail) > 0 {
 		tailc = *NewCell(m, tail)
+		tailWidth = tailc.Width
 	}
 
 	decoder := ansi.DecodeSequenceWc[T]
@@ -118,9 +139,16 @@ func printString[T []byte | string](
 		decoder = ansi.DecodeSequence[T]
 	}
 
+	var setCell func(x, y int, c *Cell)
 	if s == nil {
 		lines = []Line{}
+	} else {
+		setCell = screenCellSetter(s)
 	}
+
+	minX, minY := bounds.Min.X, bounds.Min.Y
+	maxX, maxY := bounds.Max.X, bounds.Max.Y
+	truncateX := maxX - tailWidth
 
 	var cell Cell
 	var style Style
@@ -144,24 +172,23 @@ func printString[T []byte | string](
 				x += width
 			} else {
 				// Drawing to screen: handle wrapping, truncation, and bounds
-				if !truncate && x+cell.Width > bounds.Max.X && y+1 < bounds.Max.Y {
+				if !truncate && x+cell.Width > maxX && y+1 < maxY {
 					// Wrap the string to the width of the window
-					x = bounds.Min.X
+					x = minX
 					y++
 				}
 
-				pos := Pos(x, y)
-				if pos.In(bounds) {
-					if truncate && tailc.Width > 0 && x+cell.Width > bounds.Max.X-tailc.Width {
+				if x >= minX && x < maxX && y >= minY && y < maxY {
+					if truncate && tailWidth > 0 && x+cell.Width > truncateX {
 						// Truncate the string and append the tail if any.
 						cell = tailc
 						cell.Style = style
 						cell.Link = link
-						s.SetCell(x, y, &cell)
-						x += tailc.Width
+						setCell(x, y, &cell)
+						x += tailWidth
 					} else {
 						// Print the cell to the screen
-						s.SetCell(x, y, &cell)
+						setCell(x, y, &cell)
 						x += width
 					}
 				}
@@ -193,7 +220,7 @@ func printString[T []byte | string](
 				if s == nil {
 					x = 0
 				} else {
-					x = bounds.Min.X
+					x = minX
 				}
 			default:
 				cell.Content += string(seq)
@@ -204,7 +231,7 @@ func printString[T []byte | string](
 		state = newState
 		str = str[n:]
 
-		if y >= bounds.Max.Y {
+		if s != nil && y >= maxY {
 			// We've reached the bottom of the bounds, stop processing further
 			// lines.
 			break
@@ -213,10 +240,28 @@ func printString[T []byte | string](
 
 	// Make sure to set the last cell if it's not empty.
 	if !cell.IsZero() && s != nil {
-		s.SetCell(x, y, &cell)
+		setCell(x, y, &cell)
 	}
 
 	return lines
+}
+
+func screenCellSetter(scr Screen) func(x, y int, c *Cell) {
+	switch s := scr.(type) {
+	case *TerminalScreen:
+		return func(x, y int, c *Cell) {
+			s.win.SetCell(x, y, c)
+			s.rbuf.Buffer.SetCell(x, y, c)
+		}
+	case ScreenBuffer:
+		return s.RenderBuffer.Buffer.SetCell
+	case *ScreenBuffer:
+		return s.RenderBuffer.Buffer.SetCell
+	case *Window:
+		return s.Buffer.SetCell
+	default:
+		return scr.SetCell
+	}
 }
 
 // ReadStyle reads a Select Graphic Rendition (SGR) escape sequences from a

--- a/terminal_screen.go
+++ b/terminal_screen.go
@@ -85,6 +85,31 @@ func (s *TerminalScreen) CellAt(x, y int) *Cell {
 // SetCell sets the cell at the specified x and y coordinates.
 func (s *TerminalScreen) SetCell(x, y int, cell *Cell) {
 	s.win.SetCell(x, y, cell)
+	s.rbuf.SetCell(x, y, cell)
+}
+
+// Fill fills the terminal screen with the given cell.
+func (s *TerminalScreen) Fill(cell *Cell) {
+	s.win.Fill(cell)
+	s.rbuf.Fill(cell)
+}
+
+// FillArea fills the terminal screen area with the given cell.
+func (s *TerminalScreen) FillArea(cell *Cell, area Rectangle) {
+	s.win.FillArea(cell, area)
+	s.rbuf.FillArea(cell, area)
+}
+
+// Clear clears the terminal screen.
+func (s *TerminalScreen) Clear() {
+	s.win.Clear()
+	s.rbuf.Clear()
+}
+
+// ClearArea clears the given area of the terminal screen.
+func (s *TerminalScreen) ClearArea(area Rectangle) {
+	s.win.ClearArea(area)
+	s.rbuf.ClearArea(area)
 }
 
 // Bounds returns the bounds of the terminal screen as a rectangle.
@@ -128,7 +153,7 @@ func (s *TerminalScreen) Resize(width, height int) error {
 // [TerminalScreen.Flush].
 func (s *TerminalScreen) Display(d Drawable) error {
 	if d != nil {
-		s.win.Clear()
+		s.Clear()
 		d.Draw(s, s.win.Bounds())
 	}
 	if err := s.Render(); err != nil {
@@ -143,21 +168,6 @@ func (s *TerminalScreen) Display(d Drawable) error {
 // The changes can be committed to the underlying writer by calling the
 // [TerminalScreen.Flush] method.
 func (s *TerminalScreen) Render() error {
-	for y := 0; y < s.win.Height(); y++ {
-		for x := 0; x < s.win.Width(); {
-			cell := s.win.CellAt(x, y)
-			if cell == nil || cell.IsZero() {
-				x++
-				continue
-			}
-			s.rbuf.SetCell(x, y, cell)
-			width := cell.Width
-			if width <= 0 {
-				width = 1
-			}
-			x += width
-		}
-	}
 	s.rend.Render(s.rbuf)
 	return s.rend.Flush()
 }

--- a/terminal_screen_test.go
+++ b/terminal_screen_test.go
@@ -1,0 +1,201 @@
+package uv
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRenderBufferFillAreaMarksTouched(t *testing.T) {
+	b := NewRenderBuffer(5, 3)
+	cell := &Cell{Content: "X", Width: 1}
+
+	b.FillArea(cell, Rect(1, 1, 2, 1))
+
+	if got := b.CellAt(1, 1); got == nil || got.Content != "X" {
+		t.Fatalf("expected filled cell at 1,1, got %#v", got)
+	}
+	if got := b.CellAt(2, 1); got == nil || got.Content != "X" {
+		t.Fatalf("expected filled cell at 2,1, got %#v", got)
+	}
+	line := b.Touched[1]
+	if line == nil || line.FirstCell != 1 || line.LastCell != 3 {
+		t.Fatalf("expected touched span [1,3) on line 1, got %#v", line)
+	}
+}
+
+func TestTerminalScreenSetCellWritesThroughRenderBuffer(t *testing.T) {
+	var out bytes.Buffer
+	s := NewTerminalScreen(&out, Environ{"TERM=xterm-256color"})
+	if err := s.Resize(4, 2); err != nil {
+		t.Fatalf("resize: %v", err)
+	}
+
+	cell := &Cell{Content: "A", Width: 1}
+	s.SetCell(2, 1, cell)
+
+	if got := s.rbuf.CellAt(2, 1); got == nil || got.Content != "A" {
+		t.Fatalf("expected render buffer cell A at 2,1, got %#v", got)
+	}
+	line := s.rbuf.Touched[1]
+	if line == nil || line.FirstCell != 2 || line.LastCell != 3 {
+		t.Fatalf("expected touched span [2,3) on line 1, got %#v", line)
+	}
+}
+
+func TestTerminalScreenRenderUsesRenderBufferDirectly(t *testing.T) {
+	var out bytes.Buffer
+	s := NewTerminalScreen(&out, Environ{"TERM=xterm-256color"})
+	if err := s.Resize(3, 1); err != nil {
+		t.Fatalf("resize: %v", err)
+	}
+
+	s.rbuf.SetCell(0, 0, &Cell{Content: "A", Width: 1})
+	s.win.SetCell(0, 0, &Cell{Content: "B", Width: 1})
+
+	if err := s.Render(); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if got := s.rend.curbuf.CellAt(0, 0); got == nil || got.Content != "A" {
+		t.Fatalf("expected renderer current buffer to use render buffer cell A, got %#v", got)
+	}
+	if bytes.Contains(out.Bytes(), []byte("B")) {
+		t.Fatalf("expected output to avoid stale window cell B, got %q", out.String())
+	}
+}
+
+func TestTerminalScreenDisplayClearsRenderBuffer(t *testing.T) {
+	var out bytes.Buffer
+	s := NewTerminalScreen(&out, Environ{"TERM=xterm-256color"})
+	if err := s.Resize(3, 1); err != nil {
+		t.Fatalf("resize: %v", err)
+	}
+
+	first := DrawableFunc(func(scr Screen, _ Rectangle) {
+		scr.SetCell(0, 0, &Cell{Content: "A", Width: 1})
+		scr.SetCell(1, 0, &Cell{Content: "B", Width: 1})
+	})
+	second := DrawableFunc(func(scr Screen, _ Rectangle) {
+		scr.SetCell(0, 0, &Cell{Content: "X", Width: 1})
+	})
+
+	if err := s.Display(first); err != nil {
+		t.Fatalf("first display: %v", err)
+	}
+	if err := s.Display(second); err != nil {
+		t.Fatalf("second display: %v", err)
+	}
+
+	if got := s.rbuf.CellAt(1, 0); got == nil || got.Content != " " {
+		t.Fatalf("expected second display clear to blank stale cell at 1,0, got %#v", got)
+	}
+	if got := s.rbuf.CellAt(0, 0); got == nil || got.Content != "X" {
+		t.Fatalf("expected second display cell X at 0,0, got %#v", got)
+	}
+}
+
+func TestStyledStringDrawUpdatesTerminalScreenBuffers(t *testing.T) {
+	var out bytes.Buffer
+	s := NewTerminalScreen(&out, Environ{"TERM=xterm-256color"})
+	if err := s.Resize(4, 1); err != nil {
+		t.Fatalf("resize: %v", err)
+	}
+
+	s.SetCell(3, 0, &Cell{Content: "Z", Width: 1})
+	NewStyledString("AB").Draw(s, s.Bounds())
+
+	for x, want := range []string{"A", "B", " ", " "} {
+		if got := s.win.CellAt(x, 0); got == nil || got.Content != want {
+			t.Fatalf("expected window cell %q at %d,0, got %#v", want, x, got)
+		}
+		if got := s.rbuf.CellAt(x, 0); got == nil || got.Content != want {
+			t.Fatalf("expected render buffer cell %q at %d,0, got %#v", want, x, got)
+		}
+	}
+}
+
+func BenchmarkTerminalScreenRenderSparseUpdates(b *testing.B) {
+	s := NewTerminalScreen(io.Discard, Environ{"TERM=xterm-256color"})
+	if err := s.Resize(80, 24); err != nil {
+		b.Fatalf("resize: %v", err)
+	}
+
+	cell := &Cell{Content: "X", Width: 1}
+	activeX, activeY := 0, 0
+	s.SetCell(activeX, activeY, cell)
+	if err := s.Render(); err != nil {
+		b.Fatalf("prime render: %v", err)
+	}
+	if err := s.Flush(); err != nil {
+		b.Fatalf("prime flush: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		nextX := (i + 1) % s.Bounds().Dx()
+		nextY := ((i + 1) / s.Bounds().Dx()) % s.Bounds().Dy()
+
+		s.SetCell(activeX, activeY, nil)
+		s.SetCell(nextX, nextY, cell)
+
+		if err := s.Render(); err != nil {
+			b.Fatalf("render: %v", err)
+		}
+		if err := s.Flush(); err != nil {
+			b.Fatalf("flush: %v", err)
+		}
+
+		activeX, activeY = nextX, nextY
+	}
+}
+
+func BenchmarkStyledStringDrawScreenBuffer(b *testing.B) {
+	const width, height = 80, 24
+
+	ss := NewStyledString(benchmarkStyledFrame(width, height))
+	scr := NewScreenBuffer(width, height)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		ss.Draw(scr, scr.Bounds())
+	}
+}
+
+func benchmarkStyledFrame(width, height int) string {
+	var out strings.Builder
+	out.Grow(height * (width + 16))
+
+	const pattern = "abcdefghijklmnopqrstuvwxyz0123456789<>[]{}+-=*/"
+	for y := 0; y < height; y++ {
+		out.WriteString("\x1b[3")
+		out.WriteString(strconv.Itoa((y % 6) + 1))
+		out.WriteByte('m')
+
+		var line strings.Builder
+		line.Grow(width)
+		line.WriteString("row ")
+		if y < 10 {
+			line.WriteByte('0')
+		}
+		line.WriteString(strconv.Itoa(y))
+		line.WriteByte(' ')
+		for line.Len() < width {
+			line.WriteString(pattern)
+		}
+
+		out.WriteString(line.String()[:width])
+		out.WriteString("\x1b[m")
+		if y < height-1 {
+			out.WriteByte('\n')
+		}
+	}
+
+	return out.String()
+}


### PR DESCRIPTION
## Summary
- keep `TerminalScreen`'s render buffer live and dirty as writes happen instead of rebuilding it from `win` on every `Render`
- add touched-aware `Fill`/`FillArea`/`Clear`/`ClearArea` helpers to `RenderBuffer` and route `TerminalScreen` clearing through them
- speed up `StyledString.Draw` by clearing through screen-level area helpers and using a draw-path fast setter for known UV screen types
- add tests and benchmarks covering the live-`rbuf` path and the `StyledString.Draw` caller hot path

## Details
`TerminalScreen` now writes through to `rbuf` in `SetCell` and exposes `Fill`, `FillArea`, `Clear`, and `ClearArea` so callers can keep `win` and `rbuf` in sync while marking touched spans incrementally.

`Render()` now renders `rbuf` directly, and `Display()` clears through `TerminalScreen` so stale render-buffer state is dropped before redraws.

On the draw side, `StyledString.Draw` now prefers `ClearArea`/`FillArea` over a per-cell clear loop, skips CRLF normalization work when unnecessary, precomputes bounds/tail values, and uses a specialized setter for `TerminalScreen`, `ScreenBuffer`, and `Window` targets after the draw area has already been marked dirty.

## Benchmarks
On a local Apple M4 run:

- `BenchmarkTerminalScreenRenderSparseUpdates`: `22089 ns/op`, `5124 B/op`, `180 allocs/op`
- `BenchmarkStyledStringDrawScreenBuffer`: `30399 ns/op`, `131 B/op`, `2 allocs/op`

Relative to the pre-patch baseline from the same benchmark harness, sparse render moved from about `23.4µs` to `22.1µs`, and `StyledString.Draw` moved from about `44.3µs` to `30.4µs`.

## Testing
- `go test ./...`
- `go test -run '^$' -bench 'Benchmark(TerminalScreenRenderSparseUpdates|StyledStringDrawScreenBuffer)$' -benchmem ./`
