### PR TITLE
Kitty text-sizing protocol support in StyledString

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -9,6 +9,26 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
+// isCursorMoveCell reports whether the cell's content is a pure CSI cursor
+// movement sequence (CUF, CUB, CUU, CUD, CHA, VPA, CUP, etc.): bytes whose
+// sole effect on the terminal is relocating the cursor. Such cells never
+// paint anything visible, so any SGR or hyperlink state set before them is
+// wasted output and, crucially, those rendition bytes land at columns we
+// may be deliberately trying to leave untouched (kitty multicell extension
+// cells).
+func isCursorMoveCell(c *Cell) bool {
+	s := c.Content
+	if len(s) < 3 || s[0] != 0x1b || s[1] != '[' {
+		return false
+	}
+	switch s[len(s)-1] {
+	// Cursor movement final bytes from the ECMA-48 / xterm CSI set.
+	case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'a', 'd', 'e', '`':
+		return true
+	}
+	return false
+}
+
 // Position represents a position in a coordinate system.
 type Position = image.Point
 
@@ -163,6 +183,17 @@ func renderLine(buf io.StringWriter, l Line) {
 		if pending.Len() > 0 {
 			_, _ = buf.WriteString(pending.String())
 			pending.Reset()
+		}
+
+		// Cursor-movement cells (CUF placeholders we seed for the spill
+		// rows of a kitty text-sizing multicell) paint nothing. Emitting
+		// SGR/link state changes around them lands rendition bytes
+		// exactly at cell positions that are multicell extensions; kitty
+		// reacts to that by rendering later escapes as literal text.
+		// Forward the content verbatim without touching the pen.
+		if isCursorMoveCell(&c) {
+			_, _ = buf.WriteString(c.String())
+			continue
 		}
 
 		if c.Style.IsZero() && !pen.IsZero() {

--- a/examples/textsizing/main.go
+++ b/examples/textsizing/main.go
@@ -1,0 +1,92 @@
+// Example: kitty text-sizing protocol.
+//
+// Demonstrates rendering text at 2x, 3x, and 4x scale using OSC 66, the
+// kitty text-sizing protocol:
+//
+//	https://sw.kovidgoyal.net/kitty/text-sizing-protocol/
+//
+// The string passed to the screen contains the OSC 66 escape verbatim;
+// ultraviolet recognises it, reserves the correct number of cells in the
+// cell buffer, and forwards the bytes to the terminal so the glyph is
+// rendered at the requested scale. On terminals that do not implement the
+// protocol the sequence is ignored and the glyph renders at its natural
+// size, so the example is safe to run anywhere.
+//
+// Run it in kitty to see the scaled glyphs. Press any key to exit.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// scale wraps s in an OSC 66 escape requesting an sx cell scale factor.
+// BEL is used as the terminator (rather than ESC+\) because it is a single
+// unambiguous byte. See styled.go for why that matters when an SGR sequence
+// follows the OSC.
+func scale(s string, sx int) string {
+	return fmt.Sprintf("\x1b]66;s=%d;%s\x07", sx, s)
+}
+
+func main() {
+	t := uv.DefaultTerminal()
+	scr := t.Screen()
+	scr.EnterAltScreen()
+
+	if err := t.Start(); err != nil {
+		log.Fatalf("start: %v", err)
+	}
+	defer t.Stop()
+
+	header := "ultraviolet + kitty text-sizing protocol"
+	footer := "press any key to exit"
+
+	lines := []string{
+		"1x " + "Hello, world!",
+		"2x " + scale("H", 2) + scale("i", 2) + "!",
+		"3x " + scale("3", 3) + scale("x", 3),
+		"4x " + scale("B", 4) + scale("I", 4) + scale("G", 4),
+		"mixed: " + scale("A", 2) + " " + scale("B", 3) + " " + scale("C", 4),
+	}
+
+	draw := func() {
+		b := scr.Bounds()
+		for y := 0; y < b.Dy(); y++ {
+			for x := 0; x < b.Dx(); x++ {
+				scr.SetCell(x, y, nil)
+			}
+		}
+
+		uv.NewStyledString(header).Draw(scr, uv.Rect(2, 1, len(header), 1))
+
+		y := 4
+		for _, l := range lines {
+			// Reserve enough vertical space for the tallest glyph on the
+			// line. The protocol scales height along with width, so a 4x
+			// line occupies 4 rows.
+			uv.NewStyledString(l).Draw(scr, uv.Rect(2, y, b.Dx()-4, 5))
+			y += 5
+		}
+
+		uv.NewStyledString(footer).Draw(scr, uv.Rect(2, b.Dy()-2, len(footer), 1))
+
+		scr.Render()
+		scr.Flush()
+	}
+
+	draw()
+	defer draw()
+
+	for ev := range t.Events() {
+		switch ev := ev.(type) {
+		case uv.WindowSizeEvent:
+			scr.Resize(ev.Width, ev.Height)
+			draw()
+		case uv.KeyPressEvent:
+			_ = ev
+			return
+		}
+	}
+}

--- a/spillrow_test.go
+++ b/spillrow_test.go
@@ -1,0 +1,55 @@
+package uv
+
+import (
+	"bytes"
+	"image/color"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/colorprofile"
+)
+
+// Emit a spill row containing: 8 styled nbsps, CUF spill cell (no-style),
+// 8 styled nbsps. Verify no SGR ends up at the CUF column.
+func TestSpillRowCUFHasNoAdjacentSGR(t *testing.T) {
+	cellbuf := NewScreenBuffer(20, 1)
+
+	nbspStyle := Style{
+		Fg: color.RGBA{R: 255, G: 250, B: 241, A: 255},
+		Bg: color.RGBA{R: 77, G: 76, B: 87, A: 255},
+	}
+
+	// 8 styled nbsps at cols 0..7.
+	for x := 0; x < 8; x++ {
+		cellbuf.SetCell(x, 0, &Cell{Content: "\u00a0", Width: 1, Style: nbspStyle})
+	}
+	// CUF skip cell at col 8, mimicking what styled.go seeds for the
+	// spill row of a kitty text-sizing multicell anchor.
+	cellbuf.SetCell(8, 0, &Cell{Content: "\x1b[2C", Width: 2})
+	// 8 more styled nbsps at cols 10..17.
+	for x := 10; x < 18; x++ {
+		cellbuf.SetCell(x, 0, &Cell{Content: "\u00a0", Width: 1, Style: nbspStyle})
+	}
+
+	var out bytes.Buffer
+	tr := NewTerminalRenderer(&out, []string{"COLORTERM=truecolor", "TERM=xterm-kitty"})
+	tr.Resize(20, 1)
+	tr.SetColorProfile(colorprofile.TrueColor)
+	tr.Render(cellbuf.RenderBuffer)
+	tr.Flush()
+
+	got := out.String()
+	t.Logf("emitted: %q", got)
+
+	// The CUF must appear.
+	if !strings.Contains(got, "\x1b[2C") {
+		t.Fatalf("CUF missing from output: %q", got)
+	}
+	// No SGR ("\x1b[...m") may appear immediately adjacent to the CUF on
+	// either side. The whole point of the CUF cell is to leave the
+	// multicell extension columns completely untouched; a pen change
+	// before or after the CUF lands an SGR byte there.
+	if strings.Contains(got, "\x1b[m\x1b[2C") || strings.Contains(got, "m\x1b[2C\x1b[") {
+		t.Errorf("SGR emitted adjacent to CUF; pen state leaked into multicell extension\n  got: %q", got)
+	}
+}

--- a/spillrow_test.go
+++ b/spillrow_test.go
@@ -9,6 +9,55 @@ import (
 	"github.com/charmbracelet/colorprofile"
 )
 
+// TestMulticellSurvivesRowRedraw verifies that a kitty text-sizing
+// multicell sitting in the middle of an otherwise-clearable line is
+// not erased by EL right when the line is redrawn with shifted
+// trailing content. The trailing-blank-only canClearWith check would
+// have let the fast path fire here and zap the multicell; the per-cell
+// non-clearable scan added to transformLine forces the slow path
+// instead, preserving the cell.
+func TestMulticellSurvivesRowRedraw(t *testing.T) {
+	cellbuf := NewScreenBuffer(20, 1)
+
+	// Frame 1: spaces, then an OSC 66 multicell at col 8 (width 2),
+	// then trailing spaces. Last cell is a clearable space — so the
+	// fast path used to be eligible.
+	for x := 0; x < 8; x++ {
+		cellbuf.SetCell(x, 0, &Cell{Content: " ", Width: 1})
+	}
+	cellbuf.SetCell(8, 0, &Cell{
+		Content: "\x1b]66;s=2;X\x07",
+		Width:   2,
+	})
+	for x := 10; x < 20; x++ {
+		cellbuf.SetCell(x, 0, &Cell{Content: " ", Width: 1})
+	}
+
+	var out bytes.Buffer
+	tr := NewTerminalRenderer(&out, []string{"COLORTERM=truecolor", "TERM=xterm-kitty"})
+	tr.Resize(20, 1)
+	tr.SetColorProfile(colorprofile.TrueColor)
+	tr.Render(cellbuf.RenderBuffer)
+	tr.Flush()
+	out.Reset()
+
+	// Frame 2: a single trailing letter at col 19 disappears, leaving
+	// the rest of the line as before. This is exactly the kind of
+	// edit that historically tempted EL right and would have wiped the
+	// multicell at col 8.
+	cellbuf.SetCell(19, 0, &Cell{Content: " ", Width: 1})
+	tr.Render(cellbuf.RenderBuffer)
+	if err := tr.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	got := out.String()
+	if strings.Contains(got, "\x1b[K") || strings.Contains(got, "\x1b[0K") {
+		t.Errorf("EL right was emitted on a row containing a multicell; "+
+			"could destroy the glyph\n  got: %q", got)
+	}
+}
+
 // Emit a spill row containing: 8 styled nbsps, CUF spill cell (no-style),
 // 8 styled nbsps. Verify no SGR ends up at the CUF column.
 func TestSpillRowCUFHasNoAdjacentSGR(t *testing.T) {

--- a/styled.go
+++ b/styled.go
@@ -3,6 +3,7 @@ package uv
 import (
 	"bytes"
 	"image/color"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
@@ -179,6 +180,40 @@ func printString[T []byte | string](
 			case ansi.HasOscPrefix(seq) && p.Command() == 8:
 				// Hyperlinks
 				ReadLink(p.Data(), &link)
+			case ansi.HasOscPrefix(seq) && p.Command() == 66:
+				// Kitty text-sizing protocol. See:
+				// https://sw.kovidgoyal.net/kitty/text-sizing-protocol/
+				//
+				// We forward the entire escape verbatim through a single
+				// wide cell so the terminal can render the scaled glyph,
+				// while reserving the right number of cells for layout.
+				w := readTextSizingWidth(p.Data())
+				if w < 1 {
+					w = 1
+				}
+				if w > 4 {
+					w = 4
+				}
+				tsCell := Cell{
+					Content: string(seq),
+					Width:   w,
+					Style:   style,
+					Link:    link,
+				}
+				if s == nil {
+					if y >= len(lines) {
+						lines = append(lines, Line{})
+					}
+					lines[y] = append(lines[y], tsCell)
+					x += w
+				} else {
+					if pos := Pos(x, y); pos.In(bounds) {
+						if !truncate || x+w <= bounds.Max.X {
+							s.SetCell(x, y, &tsCell)
+							x += w
+						}
+					}
+				}
 			case ansi.Equal(seq, T("\n")):
 				if s == nil {
 					// When building lines, we need to ensure empty lines are represented.
@@ -324,6 +359,57 @@ func ReadStyle(params ansi.Params, pen *Style) {
 			pen.Bg = ansi.BrightBlack + ansi.BasicColor(param-100) //nolint:gosec
 		}
 	}
+}
+
+// readTextSizingWidth parses the metadata section of a kitty OSC 66
+// text-sizing payload and returns the number of terminal cells the rendered
+// glyph occupies horizontally.
+//
+// The data buffer holds the bytes between the OSC introducer and the string
+// terminator, including the leading "66" command identifier:
+//
+//	66;<key=value[:key=value...]>;<text>
+//
+// Recognised metadata keys mirror the kitty docs:
+//
+//	s=<n>  scale factor; multiplies both the horizontal and vertical extent.
+//	w=<n>  explicit cell width override.
+//	h=<n>  explicit cell height (parsed but ignored: only horizontal layout
+//	       matters at the cell-buffer level).
+//
+// When neither w nor s is supplied the width defaults to 1 cell, matching
+// the natural width of a single grapheme. Multi-grapheme text payloads are
+// not yet width-measured here; callers passing wider text should set w=
+// explicitly until that work lands.
+func readTextSizingWidth(data []byte) int {
+	parts := bytes.SplitN(data, []byte{';'}, 3)
+	if len(parts) < 2 {
+		return 1
+	}
+	meta := parts[1]
+	scale := 1
+	explicit := 0
+	for _, kv := range bytes.Split(meta, []byte{':'}) {
+		eq := bytes.IndexByte(kv, '=')
+		if eq < 1 {
+			continue
+		}
+		key := string(kv[:eq])
+		val, err := strconv.Atoi(string(kv[eq+1:]))
+		if err != nil || val < 1 {
+			continue
+		}
+		switch key {
+		case "s":
+			scale = val
+		case "w":
+			explicit = val
+		}
+	}
+	if explicit > 0 {
+		return explicit
+	}
+	return scale
 }
 
 // ReadLink reads a hyperlink escape sequence from a data buffer into link.

--- a/styled.go
+++ b/styled.go
@@ -97,6 +97,64 @@ func (s *StyledString) Bounds() Rectangle {
 	return Rect(0, 0, w, h)
 }
 
+// multicellRect describes a single-row span of cells that have been claimed
+// by a previously-emitted scaled multicell glyph in this printString call.
+// Subsequent printable writes that intersect any rect are skipped so the
+// glyph's spill rows are not overwritten and erased per the kitty
+// text-sizing protocol.
+type multicellRect struct{ x, y, w int }
+
+// hasStringPrefix reports whether b begins with any of the five
+// string-state introducers (OSC, DCS, APC, SOS, PM) in either the 7-bit
+// (ESC + X) or 8-bit (single C1 byte) form. All five share the same
+// terminator semantics.
+func hasStringPrefix[T []byte | string](b T) bool {
+	return ansi.HasOscPrefix(b) ||
+		ansi.HasDcsPrefix(b) ||
+		ansi.HasApcPrefix(b) ||
+		ansi.HasSosPrefix(b) ||
+		ansi.HasPmPrefix(b)
+}
+
+// findStringEnd scans src from offset `start` for a proper string-state
+// terminator, BEL (0x07) or 7-bit ST (ESC 0x1B followed by 0x5C), and
+// returns the index *after* the terminator, or `start` if the sequence
+// is abandoned by a bare ESC.
+//
+// Critically, it does *not* treat bare 8-bit ST (0x9C) as a terminator.
+// Of every byte the ansi decoder's StringState recognises as "end of
+// string" (BEL, CAN, SUB, ESC, and ST), only 0x9C falls in the UTF-8
+// continuation-byte range (0x80-0xBF). Nerd-Font icons like U+E738
+// (encoded as 0xEE 0x9C 0xB8) therefore carry a byte the decoder
+// misinterprets as ST, truncating the payload mid-UTF-8. The workaround
+// is to treat 0x9C as data for payloads we know to be UTF-8 and rely on
+// the unambiguous 7-bit terminators (BEL, ESC+\) instead.
+func findStringEnd[T []byte | string](src T, start int) int {
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case 0x07: // BEL
+			return i + 1
+		case 0x1b: // ESC
+			if i+1 < len(src) && src[i+1] == 0x5c {
+				return i + 2
+			}
+			// Bare ESC inside a string-state sequence; the ansi
+			// decoder aborts here, so do the same.
+			return i
+		}
+	}
+	return start
+}
+
+func multicellOwned(rects []multicellRect, x, y int) bool {
+	for _, r := range rects {
+		if r.y == y && x >= r.x && x < r.x+r.w {
+			return true
+		}
+	}
+	return false
+}
+
 // printString draws a string starting at the given position. If s is nil, it
 // will build and return a slice of [Line]s instead (unwrapped, ignoring bounds).
 func printString[T []byte | string](
@@ -106,6 +164,7 @@ func printString[T []byte | string](
 	bounds Rectangle, str T,
 	truncate bool, tail string,
 ) (lines []Line) {
+	var multicells []multicellRect
 	p := ansi.GetParser()
 	defer ansi.PutParser(p)
 
@@ -129,6 +188,35 @@ func printString[T []byte | string](
 	var state byte
 	for len(str) > 0 {
 		seq, width, n, newState := decoder(str, state, p)
+
+		// Workaround for a shared-ansi-decoder bug affecting every
+		// string-state sequence (OSC, DCS, APC, SOS, PM): the decoder
+		// treats bare C1 ST (byte 0x9C) as a terminator, but 0x9C is
+		// also a valid UTF-8 continuation byte (the whole 0x80-0xBF
+		// range is). Nerd-Font icons like U+E738 (0xEE 0x9C 0xB8)
+		// carry 0x9C as a middle byte, so an OSC 66 text-sizing
+		// payload gets sliced mid-UTF-8; downstream terminals then see
+		// malformed bytes and render the tail (SGRs, the next OSC,
+		// etc.) as literal text.
+		//
+		// Of the decoder's five recognised terminators, BEL (0x07),
+		// CAN (0x18), SUB (0x1A), ESC (0x1B), ST (0x9C), only 0x9C
+		// overlaps with UTF-8 continuation bytes; the other four live
+		// in 7-bit ASCII, which UTF-8 reserves for single-byte chars.
+		//
+		// When the decoder returns a string-state sequence that ended
+		// on bare 0x9C and there's more input available, rescan from
+		// that point for the unambiguous 7-bit terminator (BEL or
+		// ESC+\) and extend the sequence. We don't re-run the parser
+		// over the extended bytes: p.Command() and the metadata
+		// portion of p.Data() were already resolved from bytes before
+		// the UTF-8 payload began.
+		if n > 0 && n < len(str) && hasStringPrefix(seq) && seq[len(seq)-1] == 0x9C {
+			if ext := findStringEnd(str, n); ext > n {
+				seq = str[:ext]
+				n = ext
+			}
+		}
 		switch width {
 		case 1, 2, 3, 4: // wide cells can go up to 4 cells wide
 			cell.Width = width
@@ -153,14 +241,20 @@ func printString[T []byte | string](
 
 				pos := Pos(x, y)
 				if pos.In(bounds) {
-					if truncate && tailc.Width > 0 && x+cell.Width > bounds.Max.X-tailc.Width {
+					switch {
+					case multicellOwned(multicells, x, y):
+						// Cell is owned by an earlier scaled multicell glyph
+						// from this same string; writing here would erase it
+						// per the kitty text-sizing rules. Step over.
+						x += width
+					case truncate && tailc.Width > 0 && x+cell.Width > bounds.Max.X-tailc.Width:
 						// Truncate the string and append the tail if any.
 						cell = tailc
 						cell.Style = style
 						cell.Link = link
 						s.SetCell(x, y, &cell)
 						x += tailc.Width
-					} else {
+					default:
 						// Print the cell to the screen
 						s.SetCell(x, y, &cell)
 						x += width
@@ -180,6 +274,52 @@ func printString[T []byte | string](
 			case ansi.HasOscPrefix(seq) && p.Command() == 8:
 				// Hyperlinks
 				ReadLink(p.Data(), &link)
+			case ansi.HasCsiPrefix(seq) && p.Command() == 'C':
+				// CUF (cursor forward). Treat the escape as a width-N
+				// placeholder cell that preserves the literal bytes so
+				// they make it back out to the terminal verbatim. This
+				// matches what we emit for the spill rows of a kitty
+				// scaled glyph (see the OSC 66 case below); without
+				// this round-trip handling, the canvas's CUF placeholders
+				// would be silently dropped during re-parse and the cells
+				// after them would shift left into the multicell's spill,
+				// erasing the glyph.
+				n := 1
+				if v, _, ok := p.Params().Param(0, 1); ok && v > 0 {
+					n = v
+				}
+				if n > 4 {
+					n = 4
+				}
+				cufCell := Cell{
+					Content: string(seq),
+					Width:   n,
+					Style:   style,
+				}
+				if s == nil {
+					if y >= len(lines) {
+						lines = append(lines, Line{})
+					}
+					lines[y] = append(lines[y], cufCell)
+					x += n
+				} else {
+					// If this position is already claimed by an OSC 66's
+					// spill tracking from the same string, the cell is
+					// already correctly seeded, so skip the re-write to
+					// avoid a second SetCell (with a different style
+					// captured later in parsing) and a duplicate
+					// multicell rect. We still advance x so the rest of
+					// the line lines up.
+					if !multicellOwned(multicells, x, y) {
+						if pos := Pos(x, y); pos.In(bounds) {
+							if !truncate || x+n <= bounds.Max.X {
+								s.SetCell(x, y, &cufCell)
+							}
+						}
+						multicells = append(multicells, multicellRect{x: x, y: y, w: n})
+					}
+					x += n
+				}
 			case ansi.HasOscPrefix(seq) && p.Command() == 66:
 				// Kitty text-sizing protocol. See:
 				// https://sw.kovidgoyal.net/kitty/text-sizing-protocol/
@@ -187,12 +327,25 @@ func printString[T []byte | string](
 				// We forward the entire escape verbatim through a single
 				// wide cell so the terminal can render the scaled glyph,
 				// while reserving the right number of cells for layout.
-				w := readTextSizingWidth(p.Data())
+				//
+				// When the glyph also spans multiple rows (s>1 or h>1),
+				// we additionally seed CUF "cursor forward" placeholder
+				// cells in the spill rows. The kitty docs explicitly
+				// recommend moving the cursor past a multicell when
+				// writing the row below it; without this, any subsequent
+				// write into the spill cells erases the entire glyph.
+				w, h := readTextSizingDims(p.Data())
 				if w < 1 {
 					w = 1
 				}
+				if h < 1 {
+					h = 1
+				}
 				if w > 4 {
 					w = 4
+				}
+				if h > 4 {
+					h = 4
 				}
 				tsCell := Cell{
 					Content: string(seq),
@@ -207,11 +360,39 @@ func printString[T []byte | string](
 					lines[y] = append(lines[y], tsCell)
 					x += w
 				} else {
+					placed := false
 					if pos := Pos(x, y); pos.In(bounds) {
 						if !truncate || x+w <= bounds.Max.X {
 							s.SetCell(x, y, &tsCell)
-							x += w
+							placed = true
 						}
+					}
+					if placed && h > 1 {
+						// Skip cells deliberately carry NO style. When rendered
+						// back out they become `CUF(w)` with a preceding style
+						// reset, so no fg/bg/bold changes land at a position
+						// that is a multicell extension in the terminal. Some
+						// kitty builds mis-render SGR bytes emitted
+						// inside/adjacent to a multicell extension as literal
+						// text; keeping the span around the CUF stylistically
+						// neutral avoids that whole class of parser state
+						// confusion. The visible result is identical because
+						// CUF doesn't paint cells.
+						skip := Cell{
+							Content: ansi.CursorForward(w),
+							Width:   w,
+						}
+						for dy := 1; dy < h; dy++ {
+							ny := y + dy
+							if pos := Pos(x, ny); !pos.In(bounds) {
+								break
+							}
+							s.SetCell(x, ny, &skip)
+							multicells = append(multicells, multicellRect{x: x, y: ny, w: w})
+						}
+					}
+					if placed {
+						x += w
 					}
 				}
 			case ansi.Equal(seq, T("\n")):
@@ -361,9 +542,9 @@ func ReadStyle(params ansi.Params, pen *Style) {
 	}
 }
 
-// readTextSizingWidth parses the metadata section of a kitty OSC 66
-// text-sizing payload and returns the number of terminal cells the rendered
-// glyph occupies horizontally.
+// readTextSizingDims parses the metadata section of a kitty OSC 66
+// text-sizing payload and returns the cell dimensions (width, height) the
+// rendered glyph occupies.
 //
 // The data buffer holds the bytes between the OSC introducer and the string
 // terminator, including the leading "66" command identifier:
@@ -374,21 +555,20 @@ func ReadStyle(params ansi.Params, pen *Style) {
 //
 //	s=<n>  scale factor; multiplies both the horizontal and vertical extent.
 //	w=<n>  explicit cell width override.
-//	h=<n>  explicit cell height (parsed but ignored: only horizontal layout
-//	       matters at the cell-buffer level).
+//	h=<n>  explicit cell height override.
 //
-// When neither w nor s is supplied the width defaults to 1 cell, matching
-// the natural width of a single grapheme. Multi-grapheme text payloads are
-// not yet width-measured here; callers passing wider text should set w=
-// explicitly until that work lands.
-func readTextSizingWidth(data []byte) int {
+// When neither w nor s is supplied the width defaults to 1; the same applies
+// to height. Multi-grapheme text payloads are not yet width-measured here;
+// callers passing wider text should set w= explicitly until that work lands.
+func readTextSizingDims(data []byte) (int, int) {
 	parts := bytes.SplitN(data, []byte{';'}, 3)
 	if len(parts) < 2 {
-		return 1
+		return 1, 1
 	}
 	meta := parts[1]
 	scale := 1
-	explicit := 0
+	explicitW := 0
+	explicitH := 0
 	for _, kv := range bytes.Split(meta, []byte{':'}) {
 		eq := bytes.IndexByte(kv, '=')
 		if eq < 1 {
@@ -403,13 +583,20 @@ func readTextSizingWidth(data []byte) int {
 		case "s":
 			scale = val
 		case "w":
-			explicit = val
+			explicitW = val
+		case "h":
+			explicitH = val
 		}
 	}
-	if explicit > 0 {
-		return explicit
+	w := explicitW
+	if w == 0 {
+		w = scale
 	}
-	return scale
+	h := explicitH
+	if h == 0 {
+		h = scale
+	}
+	return w, h
 }
 
 // ReadLink reads a hyperlink escape sequence from a data buffer into link.

--- a/styled_test.go
+++ b/styled_test.go
@@ -2,6 +2,7 @@ package uv
 
 import (
 	"image/color"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
@@ -428,6 +429,87 @@ func TestStyledStringEmptyLines(t *testing.T) {
 				t.Errorf("expected cell (%d, %d) %#v, got %#v", x, y, expected.CellAt(x, y), &cell)
 			}
 		}
+	}
+}
+
+// TestStyledStringKittyTextSizing exercises the kitty OSC 66 path added to
+// printString. The protocol embeds the rendered glyph inside the OSC payload
+// (https://sw.kovidgoyal.net/kitty/text-sizing-protocol/), so the round-trip
+// has to (a) preserve the full escape verbatim in the cell content and
+// (b) reserve the correct number of cells based on the metadata.
+func TestStyledStringKittyTextSizing(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		atX       int
+		wantWidth int
+		wantBytes string
+	}{
+		{
+			name:      "scale 2",
+			input:     "\x1b]66;s=2;X\x1b\\",
+			atX:       0,
+			wantWidth: 2,
+			wantBytes: "\x1b]66;s=2;X\x1b\\",
+		},
+		{
+			name:      "explicit width",
+			input:     "\x1b]66;w=3;X\x1b\\",
+			atX:       0,
+			wantWidth: 3,
+			wantBytes: "\x1b]66;w=3;X\x1b\\",
+		},
+		{
+			name:      "explicit width wins over scale",
+			input:     "\x1b]66;w=4:s=2;X\x1b\\",
+			atX:       0,
+			wantWidth: 4,
+			wantBytes: "\x1b]66;w=4:s=2;X\x1b\\",
+		},
+		{
+			name:      "no metadata defaults to 1",
+			input:     "\x1b]66;;X\x1b\\",
+			atX:       0,
+			wantWidth: 1,
+			wantBytes: "\x1b]66;;X\x1b\\",
+		},
+		{
+			name:      "follows preceding char",
+			input:     "A\x1b]66;s=2;X\x1b\\",
+			atX:       1,
+			wantWidth: 2,
+			wantBytes: "\x1b]66;s=2;X\x1b\\",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scr := NewScreenBuffer(8, 1)
+			NewStyledString(tc.input).Draw(scr, scr.Bounds())
+			got := scr.CellAt(tc.atX, 0)
+			if got == nil {
+				t.Fatalf("no cell at (%d, 0)", tc.atX)
+			}
+			if got.Width != tc.wantWidth {
+				t.Errorf("width: want %d, got %d", tc.wantWidth, got.Width)
+			}
+			if got.Content != tc.wantBytes {
+				t.Errorf("content:\n  want %q\n  got  %q", tc.wantBytes, got.Content)
+			}
+		})
+	}
+}
+
+// TestStyledStringKittyTextSizingRoundTrip verifies the Cell makes it all
+// the way through the renderer, so a downstream terminal would actually see
+// the OSC bytes that drive the scaling.
+func TestStyledStringKittyTextSizingRoundTrip(t *testing.T) {
+	const osc = "\x1b]66;s=2;X\x1b\\"
+	scr := NewScreenBuffer(4, 1)
+	NewStyledString(osc).Draw(scr, scr.Bounds())
+	out := scr.Render()
+	if !strings.Contains(out, osc) {
+		t.Fatalf("OSC 66 escape not found in render output:\n  want substring %q\n  got           %q", osc, out)
 	}
 }
 

--- a/styled_test.go
+++ b/styled_test.go
@@ -1,6 +1,7 @@
 package uv
 
 import (
+	"bytes"
 	"image/color"
 	"strings"
 	"testing"
@@ -480,6 +481,26 @@ func TestStyledStringKittyTextSizing(t *testing.T) {
 			wantWidth: 2,
 			wantBytes: "\x1b]66;s=2;X\x1b\\",
 		},
+		{
+			// Callers that emit OSC 66 followed directly by an SGR are
+			// advised to use BEL as the terminator instead of ST, because
+			// ST is ESC+\\ and the trailing ESC can get concatenated with
+			// the following ESC[... into a single ambiguous blob for some
+			// terminal parsers. The cell buffer must still recognise and
+			// forward a BEL-terminated OSC 66 unchanged.
+			name:      "BEL terminator",
+			input:     "\x1b]66;s=2;X\x07",
+			atX:       0,
+			wantWidth: 2,
+			wantBytes: "\x1b]66;s=2;X\x07",
+		},
+		{
+			name:      "BEL terminator followed by SGR",
+			input:     "\x1b]66;s=2;X\x07\x1b[31m",
+			atX:       0,
+			wantWidth: 2,
+			wantBytes: "\x1b]66;s=2;X\x07",
+		},
 	}
 
 	for _, tc := range cases {
@@ -510,6 +531,124 @@ func TestStyledStringKittyTextSizingRoundTrip(t *testing.T) {
 	out := scr.Render()
 	if !strings.Contains(out, osc) {
 		t.Fatalf("OSC 66 escape not found in render output:\n  want substring %q\n  got           %q", osc, out)
+	}
+}
+
+// TestStyledStringKittyTextSizingMultiRow asserts that a scaled glyph also
+// reserves CUF placeholder cells in the rows it spills into, and that a
+// trailing space in the input does not overwrite those placeholders.
+func TestStyledStringKittyTextSizingMultiRow(t *testing.T) {
+	// Layout: "Xose<NL>spaces" - the X is the OSC 66 anchor at scale 2;
+	// the spaces line below should be partially short-circuited where
+	// the spill cells sit.
+	const osc = "\x1b]66;s=2;X\x1b\\"
+	// Pad the icon line to fill 4 cells so the spill is aligned with
+	// known columns; spacer line is 4 spaces.
+	input := osc + "\n    "
+
+	scr := NewScreenBuffer(4, 2)
+	NewStyledString(input).Draw(scr, scr.Bounds())
+
+	anchor := scr.CellAt(0, 0)
+	if anchor == nil || anchor.Width != 2 || anchor.Content != osc {
+		t.Fatalf("anchor cell wrong: %#v", anchor)
+	}
+
+	spill := scr.CellAt(0, 1)
+	if spill == nil {
+		t.Fatal("spill cell not set; expected CUF placeholder")
+	}
+	if spill.Width != 2 {
+		t.Errorf("spill cell width: want 2, got %d", spill.Width)
+	}
+	wantCUF := "\x1b[2C"
+	if spill.Content != wantCUF {
+		t.Errorf("spill cell content: want %q, got %q", wantCUF, spill.Content)
+	}
+
+	// The spaces written to (0, 1) and (1, 1) should NOT have overwritten
+	// the placeholder. (2, 1) and (3, 1) should be regular space cells.
+	if got := scr.CellAt(2, 1); got == nil || got.Content != " " {
+		t.Errorf("(2, 1) want space, got %#v", got)
+	}
+	if got := scr.CellAt(3, 1); got == nil || got.Content != " " {
+		t.Errorf("(3, 1) want space, got %#v", got)
+	}
+
+	// The spill CUF cell must carry *no* style. Emitting an SGR change
+	// adjacent to a multicell extension is what some kitty builds
+	// mis-render as literal SGR text ("[38;2;...m"). A zero style means
+	// renderLine emits at most a plain ResetStyle around the CUF.
+	if !spill.Style.IsZero() {
+		t.Errorf("spill cell style must be zero; got %#v", spill.Style)
+	}
+}
+
+// TestStyledStringKittyTextSizingUTF8Continuation covers OSC 66 payloads
+// whose UTF-8 text contains byte 0x9C (C1 ST). Nerd-Font icons like
+// U+E738 (0xEE 0x9C 0xB8) land here; the shared ansi decoder treats the
+// middle 0x9C as a C1 String Terminator and truncates the OSC payload
+// mid-UTF-8, which causes kitty to see malformed bytes and render the
+// tail of the emission as literal text. The fix in printString must
+// recognise the pattern and rescan for the real BEL/ESC+\ terminator.
+func TestStyledStringKittyTextSizingUTF8Continuation(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "BEL terminator, 0x9C continuation byte",
+			input: "\x1b]66;s=2;\ue738\x07",
+		},
+		{
+			name:  "ST terminator, 0x9C continuation byte",
+			input: "\x1b]66;s=2;\ue738\x1b\\",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scr := NewScreenBuffer(4, 1)
+			NewStyledString(tc.input).Draw(scr, scr.Bounds())
+			cell := scr.CellAt(0, 0)
+			if cell == nil {
+				t.Fatal("no cell at (0, 0)")
+			}
+			if cell.Width != 2 {
+				t.Errorf("width: want 2, got %d", cell.Width)
+			}
+			if cell.Content != tc.input {
+				t.Errorf("content truncated mid-UTF-8:\n  want %q\n  got  %q", tc.input, cell.Content)
+			}
+		})
+	}
+}
+
+// TestTerminalRendererForwardsKittyOSC66 mirrors the path bubbletea uses:
+// View.Content goes into a styled string, the styled string draws into the
+// cell buffer, and TerminalRenderer.Render flushes that buffer to the
+// terminal. We assert the OSC bytes show up in the bytes the renderer
+// would have written to the terminal.
+func TestTerminalRendererForwardsKittyOSC66(t *testing.T) {
+	const osc = "\x1b]66;s=2;X\x1b\\"
+
+	// Two frames: empty first, then content. The renderer diffs against
+	// the previous frame, so emitting on the very first paint requires a
+	// non-empty frame after an initialised state.
+	cellbuf := NewScreenBuffer(4, 1)
+	NewStyledString(osc).Draw(cellbuf, cellbuf.Bounds())
+
+	var out bytes.Buffer
+	tr := NewTerminalRenderer(&out, nil)
+	tr.Resize(4, 1)
+	tr.Render(cellbuf.RenderBuffer)
+	if err := tr.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, osc) {
+		t.Fatalf("TerminalRenderer dropped OSC 66\n  want substring %q\n  got           %q", osc, got)
 	}
 }
 

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -860,8 +860,41 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 		return
 	}
 
+	// Pick the slow per-cell path when EL would visibly damage cell
+	// content. Two reasons can trigger it:
+	//
+	//   1. The line's "blank" template (last cell) isn't clearable via
+	//      EL — the original check.
+	//   2. ANY cell on the new or old line is non-clearable, e.g. a
+	//      kitty text-sizing multicell anchor or its CUF spill cell.
+	//      EL right can fire from several branches below and reach a
+	//      multicell sitting in the middle of the line, erasing it.
+	//      The trailing-blank-only check is not enough on its own.
+	//
+	// Without the per-cell scan, the only safe way for downstream code
+	// to use multicells was to fill every row with non-clearable cells
+	// (nbsp) so the trailing-cell guard tripped — which forced the
+	// slow path on every row and made multicell-heavy frames
+	// significantly slower than they need to be. The scan is O(width)
+	// per line and runs once per frame; in practice it's dominated by
+	// the SGR emission it lets us short-circuit on rows that don't
+	// need protection.
 	blank = newLine.At(newbuf.Width() - 1)
-	if blank != nil && !canClearWith(blank) {
+	slowPath := blank != nil && !canClearWith(blank)
+	if !slowPath {
+		w := newbuf.Width()
+		for x := 0; x < w; x++ {
+			if c := newLine.At(x); c != nil && !canClearWith(c) {
+				slowPath = true
+				break
+			}
+			if c := oldLine.At(x); c != nil && !canClearWith(c) {
+				slowPath = true
+				break
+			}
+		}
+	}
+	if slowPath {
 		// Find the last differing cell
 		nLastCell = newbuf.Width() - 1
 		for nLastCell > firstCell && cellEqual(newLine.At(nLastCell), oldLine.At(nLastCell)) {

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -502,6 +502,21 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 		s.atPhantom = false
 	}
 
+	// Cursor-movement-only cells (the CUF placeholders seeded for the
+	// spill rows of a kitty text-sizing multicell) paint nothing visible.
+	// Skipping updatePen keeps SGR bytes from landing on cells that are
+	// multicell extensions in the terminal; kitty reacts to SGR at an
+	// extension cell by rendering subsequent escape sequences as literal
+	// text. Forward the content verbatim and just bump the cursor.
+	if cell != nil && isCursorMoveCell(cell) {
+		_, _ = s.buf.WriteString(cell.Content)
+		s.cur.X += cell.Width
+		if s.cur.X >= newbuf.Width() {
+			s.atPhantom = true
+		}
+		return
+	}
+
 	s.updatePen(cell)
 	cellWidth := 1
 	if cell == nil {


### PR DESCRIPTION
## What

Teaches `StyledString` / `printString` about the [kitty text-sizing protocol](https://sw.kovidgoyal.net/kitty/text-sizing-protocol/) (OSC 66) so scaled glyphs survive a full round-trip through the cell buffer. Anything that ultimately renders via `StyledString.Draw` (lipgloss canvas, bubbletea `View.Content`, the renderer test helpers, etc.) can now embed OSC 66 escapes and have the scaled glyphs show up in kitty.

## Why

Without this, OSC 66 payloads hit the `default` arm of `printString`, get accumulated into a pending `Cell`, and are then overwritten by the next printable grapheme. The bytes never reach the terminal and the buffer's width accounting is off by whatever the glyph was supposed to reserve. Any TUI using lipgloss or bubbletea to render is therefore locked out of the protocol, even on a terminal that otherwise supports it.

## How

Three commits on the branch, each doing one thing:

1. **`feat(styled): forward kitty OSC 66 text-sizing through cell buffer`**
   Mirrors the OSC 8 (hyperlink) treatment: explicitly recognise OSC 66, build a `Cell` whose `Content` is the full escape verbatim and whose `Width` comes from the `s=` / `w=` metadata. Downstream emission is unchanged; kitty sees the OSC, we reserve the right number of cells.

2. **`test(styled): cover kitty OSC 66 text-sizing path`**
   Parameterised tests for the metadata shapes the spec allows (`s=`, `w=`, mixed with `s=`, empty, offset) plus a round-trip test through `ScreenBuffer.Render` to assert the bytes survive what downstream consumers actually call.

3. **`fix(styled): make OSC 66 text-sizing survive multi-row glyphs and UTF-8 payloads`**
   The three secondary bugs that only show up once you try to render many scaled glyphs in a real layout:

   - **Spill rows got erased on the next redraw.** A 2x glyph reserves a 2x2 block; the row under the anchor is whatever the caller writes next, and a plain space / nbsp counts as destroying the multicell per the spec. When the OSC has `s>1` or `h>1` we now also seed CUF placeholder cells under the anchor and track them in a per-call rect list so subsequent printable writes step over instead of overwriting. CUF has its own case in `printString` for the re-parse path, with an ownership check to avoid double-seeding.

   - **UTF-8 continuation byte `0x9C` collided with C1 ST.** The shared ansi decoder terminates every string-state sequence on bare `0x9C`. That byte is also a valid UTF-8 continuation byte (the whole `0x80..0xBF` range is), and Nerd Font glyphs in `U+E700..U+E73F` encode as `0xEE 0x9C 0xXX`. So any such icon inside an OSC 66 payload gets sliced mid-UTF-8 and kitty renders the tail (following SGRs, the next OSC, etc.) as literal text. Of the decoder's five terminators (BEL, CAN, SUB, ESC, ST) only `0x9C` overlaps with the continuation range; the others live in 7-bit ASCII which UTF-8 reserves for single-byte chars. When a string-state sequence ends on bare `0x9C` and more input is available, rescan for the unambiguous 7-bit terminator (BEL or ESC+\\) and extend the returned slice. `p.Command` and the metadata portion of `p.Data` were already resolved from bytes before the UTF-8 payload began, so no reparse is needed.

   - **SGR emitted adjacent to a multicell extension.** `renderLine` and `TerminalRenderer.putAttrCell` diff the pen against every cell's style, including the CUF skip cells. Those diffs land SGR bytes on cells the terminal considers multicell extensions; some kitty builds react by rendering the surrounding escapes as text. Sidestep it by skipping pen/link diffing for cells whose `Content` is a pure CSI cursor-movement sequence. They paint nothing, so style around them is wasted anyway, and the extension columns stay pristine.

## Tests

```
go test -run TextSizing -v .
go test -run SpillRow -v .
```

All pass. Existing tests unaffected.

## Example

`examples/textsizing/main.go` prints a handful of lines at 1x / 2x / 3x / 4x scale using the public API. Terminals that don't implement the protocol silently ignore the escapes and fall back to natural size, so it's safe to run anywhere.

Run it:
```
cd examples && go run ./textsizing
```

Screenshot from kitty:

<img width="1900" height="1020" alt="image" src="https://github.com/user-attachments/assets/9ca6849a-3139-4a28-830f-d208d185dfbd" />

## Notes for reviewers

- The CSI-cursor-movement bypass in `renderLine` / `putAttrCell` is conservative: it keys on the content starting with `ESC [` and ending in one of the cursor-movement final bytes (`A`..`H`, `a`, `d`, `e`, `` ` ``). SGR (`m`) is deliberately not in the set because it does legitimately affect pen state.
- The `0x9C` rescue applies to every string-state prefix (OSC, DCS, APC, SOS, PM) via `hasStringPrefix`. Nothing in ultraviolet currently emits DCS/APC/SOS/PM payloads with UTF-8 content, but if anything ever does, the same fix applies without touching this code.