### PR TITLE
feat: add support for SGR-pixel mouse encoding

### DIFF
--- a/examples/mouse/main.go
+++ b/examples/mouse/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/ultraviolet/screen"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func main() {
+	t := uv.DefaultTerminal()
+	ws, err := t.GetWinsize()
+	if err != nil {
+		log.Fatalf("failed to get window size: %v", err)
+	}
+	scr := t.Screen()
+
+	if err := t.Start(); err != nil {
+		log.Fatalf("failed to start program: %v", err)
+	}
+
+	defer t.Stop()
+
+	scr.SetMouseMode(uv.MouseModeMotion)
+	scr.SetMouseEncoding(uv.MouseEncodingSGRPixel)
+
+	var lastBtn uv.MouseButton
+	var lastX, lastY int
+
+	var width int
+
+	display := func() {
+		label := fmt.Sprintf(" Button: %-12s Position: (%d, %d)", lastBtn, lastX, lastY)
+		var st uv.Style
+		st.Bg = ansi.BasicColor(4)
+		st.Fg = ansi.Black
+		bg := uv.EmptyCell
+		bg.Style = st
+		screen.FillArea(scr, &bg, uv.Rect(0, 0, width, 1))
+		for i, r := range label {
+			scr.SetCell(i, 0, &uv.Cell{
+				Content: string(r),
+				Style:   st,
+				Width:   1,
+			})
+		}
+		scr.Render()
+		scr.Flush()
+	}
+
+	// initial render
+	display()
+
+	for ev := range t.Events() {
+		switch ev := ev.(type) {
+		case uv.WindowSizeEvent:
+			width = ev.Width
+			ws.Col = uint16(ev.Width)
+			ws.Row = uint16(ev.Height)
+			scr.Resize(width, 1)
+
+			// Query the pixel dimensions of the window in-case this platform
+			// doesn't report them via Termios [uv.Terminal.GetWinsize].
+			_, _ = scr.WriteString(ansi.WindowOp(4))
+
+			display()
+		case uv.PixelSizeEvent:
+			ws.Xpixel = uint16(ev.Width)
+			ws.Ypixel = uint16(ev.Height)
+		case uv.KeyPressEvent:
+			switch {
+			case ev.MatchString("q", "ctrl+c"):
+				return
+			}
+		case uv.MouseEvent:
+			m := ev.Mouse()
+			m = uv.MousePixelToCell(m, ws)
+			lastX = m.X
+			lastY = m.Y
+			if m.Button != uv.MouseNone {
+				lastBtn = m.Button
+			}
+			scr.InsertAbove(fmt.Sprintf("%-20s (%d, %d) %s", ev.String(), m.X, m.Y, m.Button))
+			display()
+		}
+	}
+}

--- a/key_test.go
+++ b/key_test.go
@@ -1841,6 +1841,72 @@ func TestParseSGRMouseEvent(t *testing.T) {
 	}
 }
 
+func TestMousePixelToCell(t *testing.T) {
+	tt := []struct {
+		name     string
+		mouse    Mouse
+		ws       *Winsize
+		expected Mouse
+	}{
+		{
+			name:     "standard 80x24 terminal",
+			mouse:    Mouse{X: 480, Y: 312, Button: MouseLeft},
+			ws:       &Winsize{Row: 24, Col: 80, Xpixel: 560, Ypixel: 312},
+			expected: Mouse{X: 68, Y: 24, Button: MouseLeft},
+		},
+		{
+			name:     "top-left pixel",
+			mouse:    Mouse{X: 0, Y: 0, Button: MouseLeft},
+			ws:       &Winsize{Row: 24, Col: 80, Xpixel: 560, Ypixel: 312},
+			expected: Mouse{X: 0, Y: 0, Button: MouseLeft},
+		},
+		{
+			name:     "bottom-right pixel",
+			mouse:    Mouse{X: 559, Y: 311, Button: MouseRight},
+			ws:       &Winsize{Row: 24, Col: 80, Xpixel: 560, Ypixel: 312},
+			expected: Mouse{X: 79, Y: 23, Button: MouseRight},
+		},
+		{
+			name:     "exact cell boundary pixel",
+			mouse:    Mouse{X: 6, Y: 12, Button: MouseLeft},
+			ws:       &Winsize{Row: 24, Col: 80, Xpixel: 480, Ypixel: 288},
+			expected: Mouse{X: 1, Y: 1, Button: MouseLeft},
+		},
+		{
+			name:     "preserves modifiers",
+			mouse:    Mouse{X: 240, Y: 156, Button: MouseMiddle, Mod: ModAlt},
+			ws:       &Winsize{Row: 24, Col: 80, Xpixel: 560, Ypixel: 312},
+			expected: Mouse{X: 34, Y: 12, Button: MouseMiddle, Mod: ModAlt},
+		},
+		{
+			name:     "zero pixel dimensions returns zero cell",
+			mouse:    Mouse{X: 480, Y: 312, Button: MouseLeft},
+			ws:       &Winsize{Row: 24, Col: 80, Xpixel: 0, Ypixel: 0},
+			expected: Mouse{X: 0, Y: 0, Button: MouseLeft},
+		},
+		{
+			name:     "pixel position larger than window",
+			mouse:    Mouse{X: 1200, Y: 800, Button: MouseLeft},
+			ws:       &Winsize{Row: 24, Col: 80, Xpixel: 560, Ypixel: 312},
+			expected: Mouse{X: 171, Y: 61, Button: MouseLeft},
+		},
+	}
+
+	for i := range tt {
+		tc := tt[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := MousePixelToCell(tc.mouse, tc.ws)
+			if tc.expected != actual {
+				t.Fatalf("expected %#v but got %#v",
+					tc.expected,
+					actual,
+				)
+			}
+		})
+	}
+}
+
 // TestMatchStrings tests the MatchStrings method
 func TestMatchStrings(t *testing.T) {
 	tests := []struct {

--- a/mouse.go
+++ b/mouse.go
@@ -27,8 +27,9 @@ type MouseEncoding uint8
 // terminal's escape sequences. The encoding is only meaningful when mouse
 // tracking is enabled via [MouseMode].
 const (
-	MouseEncodingLegacy MouseEncoding = iota // Legacy X10-compatible encoding. Coordinates limited to 223.
-	MouseEncodingSGR                         // SGR encoding (DEC mode 1006). No coordinate limit, distinguishes press/release.
+	MouseEncodingLegacy   MouseEncoding = iota // Legacy X10-compatible encoding. Coordinates limited to 223.
+	MouseEncodingSGR                           // SGR encoding (DEC mode 1006). No coordinate limit, distinguishes press/release.
+	MouseEncodingSGRPixel                      // SGR-pixel encoding (DEC mode 1016). Reports pixel coordinates.
 
 	// TODO: support these additional encodings in the future.
 	// MouseEncodingUTF8                          // UTF-8 encoding (DEC mode 1005). Coordinates limited to 223.
@@ -115,4 +116,34 @@ func (m Mouse) String() (s string) {
 	}
 
 	return s
+}
+
+// MousePixelToCell converts a mouse event with pixel coordinates to cell
+// coordinates.
+//
+// This is only meaningful when using [MouseEncodingSGRPixel] encoding, which
+// reports mouse coordinates in pixels rather than cell units. The conversion
+// is based on the terminal's reported pixel dimensions and cell dimensions.
+//
+// On Windows, or other platforms where [Terminal.GetWinsize] doesn't report
+// pixel dimensions, you can query for the terminal window pixel dimensions via
+// [ansi.WindowOp](4) and get back a [PixelSizeEvent] with the pixel
+// dimensions. You can then construct a [Winsize] struct with the pixel
+// dimensions and the cell dimensions from [Terminal.GetWinsize] and pass it to
+// this function.
+func MousePixelToCell(m Mouse, ws *Winsize) Mouse {
+	var col, row int
+	if ws.Xpixel > 0 {
+		col = m.X * int(ws.Col) / int(ws.Xpixel)
+	}
+	if ws.Ypixel > 0 {
+		row = m.Y * int(ws.Row) / int(ws.Ypixel)
+	}
+
+	return Mouse{
+		X:      col,
+		Y:      row,
+		Button: m.Button,
+		Mod:    m.Mod,
+	}
 }

--- a/mouse.go
+++ b/mouse.go
@@ -76,7 +76,8 @@ const (
 // messages.
 //
 // The X and Y coordinates are zero-based, with (0,0) being the upper left
-// corner of the terminal.
+// corner of the terminal. When using [MouseEncodingSGRPixel] (DEC mode 1016),
+// X and Y are in pixel coordinates; otherwise they are in cell coordinates.
 //
 //	// Catch all mouse events
 //	switch Event := Event.(type) {

--- a/uv.go
+++ b/uv.go
@@ -339,6 +339,8 @@ func EncodeMouseEncoding(w io.Writer, enc MouseEncoding) error {
 			ansi.ResetModeMouseExtSgrPixel
 	case MouseEncodingSGR:
 		seq = ansi.SetModeMouseExtSgr
+	case MouseEncodingSGRPixel:
+		seq = ansi.SetModeMouseExtSgrPixel
 	}
 
 	_, err := io.WriteString(w, seq) //nolint:errcheck


### PR DESCRIPTION
This adds support for the SGR-pixel mouse encoding (DEC mode 1016). This encoding reports mouse coordinates in pixels rather than cell units, which can be useful for applications that need more precise mouse input, such as drawing programs or games.

To convert mouse events with pixel coordinates to cell coordinates, you can use the new [MousePixelToCell] function, which takes a [Mouse] event and a [Winsize] struct with the terminal's pixel and cell dimensions, and returns a new [Mouse] event with the coordinates converted to cell units.

Environments where Termios is not available, such as Windows, or they implement a faulty Termios, can query for the terminal window pixel dimensions via [ansi.WindowOp](4) and get back a [PixelSizeEvent] with the pixel dimensions. They can then construct a [Winsize] struct with the pixel dimensions and the cell dimensions from [Terminal.GetWinsize] and pass it to the [MousePixelToCell] function for coordinate conversion.

Fixes: https://github.com/charmbracelet/ultraviolet/issues/111
