### PR TITLE
fix: parseOsc correctly reports ClipboardEvent selection on base64 failure

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -841,18 +841,31 @@ func (p *EventDecoder) parseOsc(b []byte) (int, Event) {
 	case 12:
 		return i, CursorColorEvent{ansi.XParseColor(data)}
 	case 52:
-		parts := strings.Split(data, ";")
-		if len(parts) != 2 || len(parts[0]) < 1 {
+		// Split data into at most 2 parts to separate the selection code from the payload.
+		// Splitting only on the first semicolon ensures that any extra semicolons do not corrupt the split.
+		parts := strings.SplitN(data, ";", 2)
+		if len(parts) != 2 {
 			return i, ClipboardEvent{}
+		}
+
+		// The selection code (parts[0]) can be empty (e.g. system selection default).
+		// We avoid returning an empty ClipboardEvent and instead fall back to the default/empty Selection.
+		var sel ClipboardSelection
+		if len(parts[0]) > 0 {
+			sel = ClipboardSelection(parts[0][0]) //nolint:unconvert
 		}
 
 		b64 := parts[1]
 		bts, err := base64.StdEncoding.DecodeString(b64)
 		if err != nil {
-			return i, ClipboardEvent{Content: parts[1]}
+			// If base64 decoding fails, we still want to report the ClipboardEvent with
+			// the parsed selection but with empty content, rather than returning raw invalid base64.
+			return i, ClipboardEvent{
+				Selection: sel,
+				Content:   "",
+			}
 		}
 
-		sel := ClipboardSelection(parts[0][0]) //nolint:unconvert
 		return i, ClipboardEvent{Selection: sel, Content: string(bts)}
 	}
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -745,3 +745,188 @@ func TestWin32Functions(t *testing.T) {
 		}
 	})
 }
+
+// TestParseOsc tests parsing of OSC sequences
+func TestParseOsc(t *testing.T) {
+	var p EventDecoder
+	tests := []struct {
+		name      string
+		input     []byte
+		wantN     int
+		wantEvent Event
+	}{
+		{
+			name:      "shortcut alt+]",
+			input:     []byte{ansi.ESC, ']'},
+			wantN:     2,
+			wantEvent: KeyPressEvent{Code: ']', Mod: ModAlt},
+		},
+		{
+			name:      "OSC 10 Foreground Color with BEL",
+			input:     []byte("\x1b]10;rgb:ffff/ffff/ffff\x07"),
+			wantN:     24,
+			wantEvent: ForegroundColorEvent{color.RGBA{R: 255, G: 255, B: 255, A: 255}},
+		},
+		{
+			name:      "OSC 11 Background Color with ST",
+			input:     []byte("\x1b]11;rgb:0000/0000/0000\x1b\\"),
+			wantN:     25,
+			wantEvent: BackgroundColorEvent{color.RGBA{R: 0, G: 0, B: 0, A: 255}},
+		},
+		{
+			name:      "OSC 12 Cursor Color with ST",
+			input:     []byte("\x1b]12;rgb:1111/2222/3333\x1b\\"),
+			wantN:     25,
+			wantEvent: CursorColorEvent{color.RGBA{R: 17, G: 34, B: 51, A: 255}},
+		},
+		{
+			name:      "OSC 52 Clipboard System Selection and valid base64",
+			input:     []byte("\x1b]52;c;aGk=\x1b\\"),
+			wantN:     13,
+			wantEvent: ClipboardEvent{Selection: 'c', Content: "hi"},
+		},
+		{
+			name:      "OSC 52 Clipboard empty selection and valid base64",
+			input:     []byte("\x1b]52;;aGk=\x1b\\"),
+			wantN:     12,
+			wantEvent: ClipboardEvent{Selection: 0, Content: "hi"},
+		},
+		{
+			name:      "OSC 52 Clipboard system selection and invalid base64",
+			input:     []byte("\x1b]52;c;!\x1b\\"),
+			wantN:     10,
+			wantEvent: ClipboardEvent{Selection: 'c', Content: ""},
+		},
+		{
+			name:      "OSC 52 Clipboard system selection and invalid base64 with multiple semicolons",
+			input:     []byte("\x1b]52;c;aGk=;foo\x1b\\"),
+			wantN:     17,
+			wantEvent: ClipboardEvent{Selection: 'c', Content: ""},
+		},
+		{
+			name:      "OSC 52 Clipboard no semicolon",
+			input:     []byte("\x1b]52;c\x1b\\"),
+			wantN:     8,
+			wantEvent: ClipboardEvent{},
+		},
+		{
+			name:      "Unknown OSC command 999",
+			input:     []byte("\x1b]999;hello\x07"),
+			wantN:     12,
+			wantEvent: UnknownOscEvent("\x1b]999;hello\x07"),
+		},
+		{
+			name:      "Cancelled OSC sequence with CAN",
+			input:     []byte("\x1b]10;rgb:0000/0000/0000\x18"),
+			wantN:     24,
+			wantEvent: ignoredEvent("\x1b]10;rgb:0000/0000/0000\x18"),
+		},
+		{
+			name:      "Cancelled OSC sequence with SUB",
+			input:     []byte("\x1b]10;rgb:0000/0000/0000\x1a"),
+			wantN:     24,
+			wantEvent: ignoredEvent("\x1b]10;rgb:0000/0000/0000\x1a"),
+		},
+		{
+			name:      "Unterminated OSC sequence",
+			input:     []byte("\x1b]10;rgb:0000"),
+			wantN:     13,
+			wantEvent: UnknownEvent("\x1b]10;rgb:0000"),
+		},
+		{
+			name:      "Invalid ST terminator",
+			input:     []byte("\x1b]10;rgb:0000/0000/0000\x1b"),
+			wantN:     24,
+			wantEvent: ignoredEvent("\x1b]10;rgb:0000/0000/0000\x1b"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, event := p.parseOsc(tt.input)
+			if n != tt.wantN {
+				t.Errorf("parseOsc() n = %d, want %d", n, tt.wantN)
+			}
+			if tt.wantEvent == nil {
+				if event != nil {
+					t.Errorf("parseOsc() event = %v, want nil", event)
+				}
+			} else {
+				switch want := tt.wantEvent.(type) {
+				case KeyPressEvent:
+					if got, ok := event.(KeyPressEvent); ok {
+						if got.Code != want.Code || got.Mod != want.Mod {
+							t.Errorf("parseOsc() = %+v, want %+v", got, want)
+						}
+					} else {
+						t.Errorf("parseOsc() = %T, want KeyPressEvent", event)
+					}
+				case ForegroundColorEvent:
+					if got, ok := event.(ForegroundColorEvent); ok {
+						r1, g1, b1, a1 := got.RGBA()
+						r2, g2, b2, a2 := want.RGBA()
+						if r1 != r2 || g1 != g2 || b1 != b2 || a1 != a2 {
+							t.Errorf("parseOsc() = %+v, want %+v", got, want)
+						}
+					} else {
+						t.Errorf("parseOsc() = %T, want ForegroundColorEvent", event)
+					}
+				case BackgroundColorEvent:
+					if got, ok := event.(BackgroundColorEvent); ok {
+						r1, g1, b1, a1 := got.RGBA()
+						r2, g2, b2, a2 := want.RGBA()
+						if r1 != r2 || g1 != g2 || b1 != b2 || a1 != a2 {
+							t.Errorf("parseOsc() = %+v, want %+v", got, want)
+						}
+					} else {
+						t.Errorf("parseOsc() = %T, want BackgroundColorEvent", event)
+					}
+				case CursorColorEvent:
+					if got, ok := event.(CursorColorEvent); ok {
+						r1, g1, b1, a1 := got.RGBA()
+						r2, g2, b2, a2 := want.RGBA()
+						if r1 != r2 || g1 != g2 || b1 != b2 || a1 != a2 {
+							t.Errorf("parseOsc() = %+v, want %+v", got, want)
+						}
+					} else {
+						t.Errorf("parseOsc() = %T, want CursorColorEvent", event)
+					}
+				case ClipboardEvent:
+					if got, ok := event.(ClipboardEvent); ok {
+						if got.Selection != want.Selection || got.Content != want.Content {
+							t.Errorf("parseOsc() = %+v, want %+v", got, want)
+						}
+					} else {
+						t.Errorf("parseOsc() = %T, want ClipboardEvent", event)
+					}
+				case UnknownOscEvent:
+					if got, ok := event.(UnknownOscEvent); ok {
+						if got != want {
+							t.Errorf("parseOsc() = %v, want %v", got, want)
+						}
+					} else {
+						t.Errorf("parseOsc() = %T, want UnknownOscEvent", event)
+					}
+				case ignoredEvent:
+					if got, ok := event.(ignoredEvent); ok {
+						if got != want {
+							t.Errorf("parseOsc() = %v, want %v", got, want)
+						}
+					} else {
+						t.Errorf("parseOsc() = %T, want ignoredEvent", event)
+					}
+				case UnknownEvent:
+					if got, ok := event.(UnknownEvent); ok {
+						if got != want {
+							t.Errorf("parseOsc() = %v, want %v", got, want)
+						}
+					} else {
+						t.Errorf("parseOsc() = %T, want UnknownEvent", event)
+					}
+				default:
+					t.Errorf("unexpected expected event type %T", tt.wantEvent)
+				}
+			}
+		})
+	}
+}

--- a/key_test.go
+++ b/key_test.go
@@ -163,7 +163,7 @@ func TestParseSequence(t *testing.T) {
 			[]byte("\x1b]52\x1b\\\x1b]52;c;!\x1b\\\x1b]52;c;aGk=\x1b\\"),
 			[]Event{
 				ClipboardEvent{},
-				ClipboardEvent{Content: "!"},
+				ClipboardEvent{Selection: 'c'},
 				ClipboardEvent{Content: "hi", Selection: 'c'},
 			},
 		},


### PR DESCRIPTION
Previously, the OSC 52 parser used `strings.Split`, which could corrupt the payload if the base64 content contained semicolons. It also required a non-empty selection code, so empty selections silently dropped the event, and on invalid `base64` it returned the raw, un-decoded string as the content instead of an empty string — causing the wrong selection and content to be reported in ClipboardEvent.

Before passing an empty clipboard event

<img width="1713" height="202" alt="Screenshot 2026-05-25 at 1 25 32 PM" src="https://github.com/user-attachments/assets/0826f6cb-df44-4098-ab20-c1f911ba3700" />

After my changes, now the base64 is correctly populated in the Clipboard Event

<img width="1713" height="159" alt="Screenshot 2026-05-25 at 1 28 47 PM" src="https://github.com/user-attachments/assets/5433254a-5a6d-437d-b81e-179c0f74cb26" />


- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
