### PR TITLE
fix(kitty-keyboard): modified navigation/function key releases

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -1530,7 +1530,6 @@ func parseKittyKeyboard(params ansi.Params) (Event Event) {
 func parseKittyKeyboardExt(params ansi.Params, k KeyPressEvent) Event {
 	// Handle Kitty keyboard protocol
 	if len(params) > 2 && // We have at least 3 parameters
-		params[0].Param(1) == 1 && // The first parameter is 1 (defaults to 1)
 		params[1].HasMore() { // The second parameter is a subparameter (separated by a ":")
 		switch params[2].Param(1) { // The third parameter is the event type (defaults to 1)
 		case 2:

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -26,5 +26,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/image v0.32.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -34,5 +34,5 @@ golang.org/x/image v0.32.0 h1:6lZQWq75h7L5IWNk0r+SCpUJ6tUVd3v4ZHnbRKLkUDQ=
 golang.org/x/image v0.32.0/go.mod h1:/R37rrQmKXtO6tYXAjtDLwQgFLHmhW+V6ayXlxzP2Pc=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/key_test.go
+++ b/key_test.go
@@ -616,6 +616,14 @@ func TestParseSequence(t *testing.T) {
 			[]Event{KeyPressEvent{Mod: ModShift | ModMeta, Code: KeyEnd}},
 		},
 		seqTest{
+			[]byte("\x1b[6;6:2~"),
+			[]Event{KeyPressEvent{Mod: ModShift | ModCtrl, Code: KeyPgDown, IsRepeat: true}},
+		},
+		seqTest{
+			[]byte("\x1b[6;6:3~"),
+			[]Event{KeyReleaseEvent{Mod: ModShift | ModCtrl, Code: KeyPgDown}},
+		},
+		seqTest{
 			[]byte("\x1b[27;4u"),
 			[]Event{KeyPressEvent{Mod: ModShift | ModAlt, Code: KeyEscape}},
 		},


### PR DESCRIPTION
This fixes an issues where modified navigation/function key releases appear to be decoded as `KeyPressEvent` instead of `KeyReleaseEvent`, as described in #117.

Closes #117.