### PR TITLE
fix: replace Windows input busy-poll with WaitForSingleObject

### DIFF
--- a/terminal_reader_windows.go
+++ b/terminal_reader_windows.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 	"unicode/utf16"
 
 	"github.com/charmbracelet/x/ansi"
@@ -31,9 +30,10 @@ func (d *TerminalReader) streamData(ctx context.Context, readc chan []byte) erro
 	var buf bytes.Buffer
 	var records []xwindows.InputRecord
 	var err error
+	peekBuf := make([]xwindows.InputRecord, readBufSize) // pre-allocate, reused across iterations
 	for {
 		for {
-			records, err = peekNConsoleInputs(cc.conin, readBufSize)
+			records, err = peekNConsoleInputsInto(cc.conin, peekBuf)
 			if cc.isCanceled() {
 				return cancelreader.ErrCanceled
 			}
@@ -44,8 +44,10 @@ func (d *TerminalReader) streamData(ctx context.Context, readc chan []byte) erro
 				break
 			}
 
-			// Sleep for a bit to avoid busy waiting.
-			time.Sleep(10 * time.Millisecond)
+			// Block until input is available using a kernel wait instead of
+			// polling with PeekConsoleInput. This eliminates CPU usage when idle.
+			// A 1s timeout ensures cancellation is detected promptly.
+			windows.WaitForSingleObject(cc.conin, 1000)
 		}
 
 		records, err = readNConsoleInputs(cc.conin, uint32(len(records))) //nolint:gosec
@@ -289,6 +291,12 @@ func peekNConsoleInputs(console windows.Handle, maxEvents uint32) ([]xwindows.In
 	records := make([]xwindows.InputRecord, maxEvents)
 	n, err := peekConsoleInput(console, records)
 	return records[:n], err
+}
+
+// peekNConsoleInputsInto reuses a pre-allocated buffer to avoid GC pressure.
+func peekNConsoleInputsInto(console windows.Handle, buf []xwindows.InputRecord) ([]xwindows.InputRecord, error) {
+	n, err := peekConsoleInput(console, buf)
+	return buf[:n], err
 }
 
 //nolint:unused


### PR DESCRIPTION
## Problem

The Windows `streamData` implementation in `terminal_reader_windows.go` uses `PeekConsoleInput` + `time.Sleep(10ms)` in a tight loop. Since `PeekConsoleInput` is non-blocking and returns immediately when no input is available, this creates a **100Hz polling loop** even when the TUI application is completely idle.

This causes noticeable CPU usage for all TUI applications on Windows that use ultraviolet for input handling.

## Solution

Replace the busy-poll with `WaitForSingleObject` on the console input handle (`conin`), which blocks in the kernel until input events are available — **zero CPU when idle**.

A 1-second timeout ensures cancellation is detected promptly.

Additionally, pre-allocate the peek buffer (`peekBuf`) and reuse it across iterations via `peekNConsoleInputsInto()`, eliminating repeated ~80KB allocations per poll cycle.

## Changes

- Replace `time.Sleep(10ms)` polling with `WaitForSingleObject(conin, 1000)`
- Add `peekNConsoleInputsInto()` to reuse pre-allocated buffer
- Remove unused `"time"` import

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Idle wakeups/sec | 100 | ≤1 |
| Idle CPU | Noticeable | ~0% |
| Input latency | ≤10ms | Immediate |
| Cancel detection | Immediate | ≤1s |

## Testing

Built and tested on Windows 11. Idle CPU dropped from noticeable usage to 0%.