### PR TITLE
fix(kitty-keyboard): Shift+non-English letter parsed as BaseCode instead of the original

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -1413,7 +1413,7 @@ func parseKittyKeyboard(params ansi.Params) (Event Event) {
 				}
 
 			case 2:
-				// shifted key + base key
+				// base key (PC-101 scancode position)
 				if b := rune(p.Param(1)); unicode.IsPrint(b) {
 					// XXX: When alternate key reporting is enabled, the protocol
 					// can return 3 things, the unicode codepoint of the key,
@@ -1423,7 +1423,6 @@ func parseKittyKeyboard(params ansi.Params) (Event Event) {
 					// when using a different language layout.
 					key.BaseCode = b
 				}
-				fallthrough
 
 			case 1:
 				// shifted key
@@ -1460,7 +1459,14 @@ func parseKittyKeyboard(params ansi.Params) (Event Event) {
 			}
 		case 2:
 			if code := p.Param(0); code != 0 {
-				key.Text += string(rune(code))
+				// The terminal may send the base code in text-as-codepoints
+				// instead of the actual shifted character. When Shift is
+				// active and ShiftedCode is available, use it instead.
+				if (key.Mod&ModShift) != 0 && key.ShiftedCode != 0 && code == int(key.BaseCode) {
+					key.Text += string(key.ShiftedCode)
+				} else {
+					key.Text += string(rune(code))
+				}
 			}
 		}
 

--- a/key_test.go
+++ b/key_test.go
@@ -675,6 +675,19 @@ func TestParseSequence(t *testing.T) {
 			[]byte("\x1b[97;;229u"),
 			[]Event{KeyPressEvent{Code: 'a', Text: "å"}},
 		},
+		// Cyrillic Shift+у on Ukrainian layout:
+		// unicode=1091(у), shifted=1059(У), base=101(e), mod=Shift, text=101(e, wrong)
+		// Text should be corrected to ShiftedCode (У) since terminal sent base code.
+		seqTest{
+			[]byte("\x1b[1091:1059:101;2;101u"),
+			[]Event{KeyPressEvent{Code: 'у', Text: "У", Mod: ModShift, ShiftedCode: 'У', BaseCode: 'e'}},
+		},
+		// Shift+4 on Ukrainian layout: terminal sends no sub-params,
+		// unicode=52(4), mod=Shift, text=59(;) — Text already correct.
+		seqTest{
+			[]byte("\x1b[52;2;59u"),
+			[]Event{KeyPressEvent{Code: '4', Text: ";", Mod: ModShift}},
+		},
 
 		// focus/blur
 		seqTest{


### PR DESCRIPTION
This is the issue in an essense

```txt
  Code=1081(й) BaseCode=113(q) ShiftedCode=113(q) Mod=1 Text="q" KeyStr="q" Keystroke="q"
  Code=1094(ц) BaseCode=119(w) ShiftedCode=119(w) Mod=1 Text="w" KeyStr="w" Keystroke="w"
  Code=1091(у) BaseCode=101(e) ShiftedCode=101(e) Mod=1 Text="e" KeyStr="e" Keystroke="e"
  Code=1082(к) BaseCode=114(r) ShiftedCode=114(r) Mod=1 Text="r" KeyStr="r" Keystroke="r"
  Code=1077(е) BaseCode=116(t) ShiftedCode=116(t) Mod=1 Text="t" KeyStr="t" Keystroke="t"
```

1. I removed `fallthrough` because `ShiftedCode` has been already set by another Param, at was just rewritten by the BaseCode.

2. I'm not entirely sure if I handled `Text` correctly, the logic is to have original `й -> Й` instead of 'q'

`go test ./...` works
