### PR TITLE
fix(renderer): correct wide character rendering across terminals

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -90,14 +90,8 @@ func (l Line) Set(x int, c *Cell) {
 
 	if cw > 1 {
 		// Mark wide cells with zero-width placeholder cells.
-		// These placeholders inherit the style from the wide cell
-		// to ensure proper rendering (e.g., background colors).
 		for j := 1; j < cw && x+j < lineWidth; j++ {
-			l[x+j] = Cell{
-				Width: 0,
-				Style: c.Style,
-				Link:  c.Link,
-			}
+			l[x+j] = Cell{}
 		}
 	}
 }

--- a/buffer.go
+++ b/buffer.go
@@ -89,10 +89,15 @@ func (l Line) Set(x int, c *Cell) {
 	}
 
 	if cw > 1 {
-		// Mark wide cells with an zero cells.
-		// We set the wide cell down below
+		// Mark wide cells with zero-width placeholder cells.
+		// These placeholders inherit the style from the wide cell
+		// to ensure proper rendering (e.g., background colors).
 		for j := 1; j < cw && x+j < lineWidth; j++ {
-			l[x+j] = Cell{}
+			l[x+j] = Cell{
+				Width: 0,
+				Style: c.Style,
+				Link:  c.Link,
+			}
 		}
 	}
 }

--- a/cell.go
+++ b/cell.go
@@ -65,6 +65,12 @@ func (c *Cell) IsZero() bool {
 	return *c == Cell{}
 }
 
+// isWidePlaceholder reports whether the cell is the continuation column of a
+// wide cell, marked with a zero display width.
+func (c *Cell) isWidePlaceholder() bool {
+	return c != nil && c.Width == 0
+}
+
 // Clone returns a copy of the cell.
 func (c *Cell) Clone() (n *Cell) {
 	n = new(Cell)

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -25,6 +25,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/image v0.32.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -32,7 +32,7 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/image v0.32.0 h1:6lZQWq75h7L5IWNk0r+SCpUJ6tUVd3v4ZHnbRKLkUDQ=
 golang.org/x/image v0.32.0/go.mod h1:/R37rrQmKXtO6tYXAjtDLwQgFLHmhW+V6ayXlxzP2Pc=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/grapheme_width_test.go
+++ b/grapheme_width_test.go
@@ -1,0 +1,117 @@
+package uv
+
+import (
+	"io"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// warningSign is U+26A0 followed by a VS16 emoji-presentation selector
+// (U+FE0F). Terminals in Unicode core mode (DEC mode 2027) measure it as a
+// wide, width-2 glyph.
+const warningSign = "\u26a0\ufe0f"
+
+func TestGraphemeWidthNegotiation(t *testing.T) {
+	s := NewTerminalScreen(io.Discard, Environ{"TERM=xterm-256color"})
+
+	if got := s.StringWidth(warningSign); got != 1 {
+		t.Fatalf("default width method: StringWidth(%q) = %d, want 1", warningSign, got)
+	}
+
+	s.enableGraphemeWidth()
+
+	if got := s.StringWidth(warningSign); got != 2 {
+		t.Fatalf("grapheme mode: StringWidth(%q) = %d, want 2", warningSign, got)
+	}
+	if s.WidthMethod() != ansi.GraphemeWidth {
+		t.Fatalf("grapheme mode: WidthMethod() = %v, want GraphemeWidth", s.WidthMethod())
+	}
+	if !s.rend.flags.Contains(tGraphemeWidth) {
+		t.Fatal("grapheme mode: renderer tGraphemeWidth flag not set")
+	}
+	if s.rend.method != ansi.GraphemeWidth {
+		t.Fatalf("grapheme mode: renderer method = %v, want GraphemeWidth", s.rend.method)
+	}
+}
+
+func TestGraphemeWidthOverride(t *testing.T) {
+	s := NewTerminalScreen(io.Discard, Environ{"TERM=xterm-256color"})
+
+	s.SetWidthMethod(ansi.GraphemeWidth)
+	if got := s.StringWidth(warningSign); got != 2 {
+		t.Fatalf("override: StringWidth(%q) = %d, want 2", warningSign, got)
+	}
+	if s.rend.method != ansi.GraphemeWidth {
+		t.Fatalf("override: renderer method = %v, want GraphemeWidth", s.rend.method)
+	}
+
+	s.SetWidthMethod(ansi.WcWidth)
+	if got := s.StringWidth(warningSign); got != 1 {
+		t.Fatalf("override back: StringWidth(%q) = %d, want 1", warningSign, got)
+	}
+}
+
+// TestGraphemeWidthGating verifies that the mode-2027 report only switches the
+// width method to grapheme clustering for settable or active states, and never
+// for not-recognized or permanently-reset terminals.
+func TestGraphemeWidthGating(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   ansi.ModeSetting
+		enabled bool
+	}{
+		{"set", ansi.ModeSet, true},
+		{"reset", ansi.ModeReset, true},
+		{"permanently set", ansi.ModePermanentlySet, true},
+		{"not recognized", ansi.ModeNotRecognized, false},
+		{"permanently reset", ansi.ModePermanentlyReset, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewTerminalScreen(io.Discard, Environ{"TERM=xterm-256color"})
+			tm := &Terminal{scr: s}
+
+			tm.handleEvent(ModeReportEvent{Mode: ansi.ModeUnicodeCore, Value: tt.value})
+
+			wantWidth := 1
+			wantMethod := ansi.Method(ansi.WcWidth)
+			if tt.enabled {
+				wantWidth = 2
+				wantMethod = ansi.GraphemeWidth
+			}
+
+			if got := s.StringWidth(warningSign); got != wantWidth {
+				t.Fatalf("StringWidth(%q) = %d, want %d", warningSign, got, wantWidth)
+			}
+			if s.rend.method != wantMethod {
+				t.Fatalf("renderer method = %v, want %v", s.rend.method, wantMethod)
+			}
+			if got := s.rend.flags.Contains(tGraphemeWidth); got != tt.enabled {
+				t.Fatalf("renderer tGraphemeWidth flag = %v, want %v", got, tt.enabled)
+			}
+		})
+	}
+}
+
+// TestGraphemeWidthGatingPreservesOverride verifies that a late mode-2027
+// report does not clobber a width method the application set explicitly.
+func TestGraphemeWidthGatingPreservesOverride(t *testing.T) {
+	s := NewTerminalScreen(io.Discard, Environ{"TERM=xterm-256color"})
+	tm := &Terminal{scr: s}
+
+	s.SetWidthMethod(ansi.WcWidth)
+
+	tm.handleEvent(ModeReportEvent{Mode: ansi.ModeUnicodeCore, Value: ansi.ModeSet})
+
+	if got := s.StringWidth(warningSign); got != 1 {
+		t.Fatalf("explicit override clobbered: StringWidth(%q) = %d, want 1", warningSign, got)
+	}
+	if s.rend.method != ansi.WcWidth {
+		t.Fatalf("explicit override clobbered: renderer method = %v, want WcWidth", s.rend.method)
+	}
+	if s.rend.flags.Contains(tGraphemeWidth) {
+		t.Fatal("explicit override clobbered: renderer tGraphemeWidth flag set")
+	}
+}

--- a/terminal.go
+++ b/terminal.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -208,6 +209,7 @@ func (t *Terminal) Start() error {
 	sendEvents := func(buf []byte, expired bool) int {
 		n, events := evs.scanEvents(buf, expired)
 		for _, ev := range events {
+			t.handleEvent(ev)
 			t.SendEvent(ev)
 		}
 		return n
@@ -290,11 +292,35 @@ func (t *Terminal) Start() error {
 
 	// Restore any previous screen state.
 	t.scr.Restore()
+	// Query whether the terminal supports Unicode core mode (DEC mode 2027) so
+	// we can negotiate grapheme-cluster width. The response is handled in the
+	// event loop.
+	t.scr.requestGraphemeWidth()
 	if err := t.scr.Flush(); err != nil {
 		return fmt.Errorf("failed to flush terminal screen: %w", err)
 	}
 
 	return nil
+}
+
+// handleEvent reacts to internal events before they are forwarded to the
+// application. It negotiates Unicode core mode (DEC mode 2027): when the
+// terminal reports the mode is in a settable or active state, it enables
+// grapheme-cluster width so wide-glyph measurement matches the terminal. The
+// event is still forwarded to the application.
+//
+// The mode is only enabled for settable/active states (mode set, reset but
+// settable, or permanently set). It is explicitly not enabled when the mode is
+// not recognized or permanently reset, since those terminals cannot honor it.
+// Enabling goes through the screen's locked write path so it cannot race with
+// the application's Render/Flush.
+func (t *Terminal) handleEvent(ev Event) {
+	if mr, ok := ev.(ModeReportEvent); ok {
+		if mr.Mode == ansi.ModeUnicodeCore &&
+			(mr.Value.IsSet() || mr.Value == ansi.ModeReset) {
+			t.scr.enableGraphemeWidth()
+		}
+	}
 }
 
 // Wait waits for the terminal event loop to exit and returns any error that

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -529,7 +529,7 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 func (s *TerminalRenderer) putCellLR(newbuf *RenderBuffer, cell *Cell) {
 	// Optimize for the lower right corner cell.
 	curX := s.cur.X
-	if cell == nil || !cell.IsZero() {
+	if !cell.isWidePlaceholder() {
 		_, _ = s.buf.WriteString(ansi.ResetModeAutoWrap)
 		s.putAttrCell(newbuf, cell)
 		// Writing to lower-right corner cell should not wrap.
@@ -586,13 +586,8 @@ func canClearWith(c *Cell) bool {
 	// NOTE: This assumes that the terminal supports bce terminfo capability
 	// which all xterm-compatible terminals and terminals that use xterm*
 	// terminal types do.
-	// We also need to check for foreground and background colors because
-	// EraseLineRight uses the current pen color, not the cell's color, and
-	// clearing cells with colors would lose the color information.
 	return c.Style.Underline == UnderlineNone &&
 		c.Style.Attrs&^(AttrBold|AttrFaint|AttrItalic|AttrBlink|AttrRapidBlink) == 0 &&
-		c.Style.Fg == nil &&
-		c.Style.Bg == nil &&
 		c.Link.IsZero()
 }
 
@@ -691,7 +686,7 @@ func (s *TerminalRenderer) putRange(newbuf *RenderBuffer, oldLine, newLine Line,
 		var j, same int
 		for j, same = start, 0; j <= end; j++ {
 			oldCell, newCell := oldLine.At(j), newLine.At(j)
-			if same == 0 && oldCell != nil && oldCell.IsZero() && newCell.IsZero() {
+			if same == 0 && oldCell.isWidePlaceholder() && newCell.isWidePlaceholder() {
 				continue
 			}
 			if cellEqual(oldCell, newCell) {
@@ -939,7 +934,7 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 			if n != 0 {
 				for n > 0 {
 					wide := newLine.At(n + 1)
-					if wide == nil || !wide.IsZero() {
+					if !wide.isWidePlaceholder() {
 						break
 					}
 					n--
@@ -947,7 +942,7 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 				}
 			} else if n >= firstCell && newLine.At(n) != nil && newLine.At(n).Width > 1 {
 				next := newLine.At(n + 1)
-				for next != nil && next.IsZero() {
+				for next.isWidePlaceholder() {
 					n++
 					oLastCell++
 					next = newLine.At(n + 1)

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -88,6 +88,9 @@ const (
 	tFullscreen
 	tMapNewline
 	tScrollOptim
+	// tGraphemeWidth indicates the terminal measures cell width using Unicode
+	// grapheme clustering (DEC mode 2027 / Unicode core).
+	tGraphemeWidth
 )
 
 // Set sets the given flags.
@@ -136,6 +139,7 @@ type TerminalRenderer struct {
 	oldnum           []int        // old indices from previous hash
 	cur, saved       cursor       // the current and saved cursors
 	flags            tFlag        // terminal writer flags.
+	method           ansi.Method  // the width method used to measure cell width
 	term             string       // the terminal type
 	clear            bool         // whether to force clear the screen
 	caps             capabilities // terminal control sequence capabilities
@@ -199,6 +203,28 @@ func (s *TerminalRenderer) SetMapNewline(v bool) {
 		s.flags.Set(tMapNewline)
 	} else {
 		s.flags.Reset(tMapNewline)
+	}
+}
+
+// SetWidthMethod sets the width method the renderer uses to measure the
+// display width of strings. This should match the width method configured on
+// the screen so that the renderer doesn't disagree with the cell widths it is
+// asked to draw.
+func (s *TerminalRenderer) SetWidthMethod(method ansi.Method) {
+	s.method = method
+}
+
+// SetGraphemeWidth sets whether the terminal measures cell width using Unicode
+// grapheme clustering (DEC mode 2027 / Unicode core). When enabled, the
+// renderer measures string width using [ansi.GraphemeWidth]; otherwise it
+// falls back to [ansi.WcWidth].
+func (s *TerminalRenderer) SetGraphemeWidth(v bool) {
+	if v {
+		s.flags.Set(tGraphemeWidth)
+		s.method = ansi.GraphemeWidth
+	} else {
+		s.flags.Reset(tGraphemeWidth)
+		s.method = ansi.WcWidth
 	}
 }
 
@@ -331,7 +357,7 @@ func (s *TerminalRenderer) PrependString(newbuf *RenderBuffer, str string) {
 	lines := strings.Split(str, "\n")
 	offset := 0
 	for _, line := range lines {
-		lineWidth := ansi.StringWidth(line)
+		lineWidth := s.method.StringWidth(line)
 		if w > 0 && lineWidth > w {
 			offset += (lineWidth / w)
 		}

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -144,6 +144,7 @@ type TerminalRenderer struct {
 	clear            bool         // whether to force clear the screen
 	caps             capabilities // terminal control sequence capabilities
 	atPhantom        bool         // whether the cursor is out of bounds and at a phantom cell
+	lineHadWide      bool         // whether the line currently being transformed contained a wide cell
 	logger           Logger       // The logger used for debugging.
 
 	// profile is the color profile to use when downsampling colors. This is
@@ -542,12 +543,8 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 		s.atPhantom = true
 	}
 
-	// For wide characters (width > 1), explicitly position the cursor to
-	// ensure we're in sync with terminals that may measure character width
-	// differently (e.g., iTerm2 uses wcwidth which measures some emojis as
-	// width 1 instead of 2).
-	if cellWidth > 1 && !s.atPhantom {
-		_, _ = s.buf.WriteString(ansi.CursorHorizontalAbsolute(s.cur.X + 1))
+	if cellWidth > 1 {
+		s.lineHadWide = true
 	}
 }
 
@@ -819,6 +816,9 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	oldLine := s.curbuf.Line(y)
 	newLine := newbuf.Line(y)
 
+	s.lineHadWide = false
+	defer s.reanchorWideLine(newbuf)
+
 	// Find the first changed cell in the line
 	blank := newLine.At(0)
 
@@ -1007,6 +1007,22 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	} else {
 		copy(oldLine, newLine)
 	}
+}
+
+// reanchorWideLine re-anchors the cursor with a single absolute horizontal
+// move after a line that contained a wide cell. This is a best-effort fallback
+// that bounds cursor desync to one line on terminals whose width model
+// disagrees with ours. When the terminal negotiated Unicode grapheme width
+// (mode 2027) the models agree, so no re-anchor is needed.
+func (s *TerminalRenderer) reanchorWideLine(newbuf *RenderBuffer) {
+	if !s.lineHadWide || s.flags.Contains(tGraphemeWidth) {
+		return
+	}
+	s.lineHadWide = false
+	if s.atPhantom || s.cur.X < 0 || s.cur.X >= newbuf.Width() {
+		return
+	}
+	_, _ = s.buf.WriteString(ansi.CursorHorizontalAbsolute(s.cur.X + 1))
 }
 
 // deleteCells deletes the count cells at the current cursor position and moves

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -487,7 +487,7 @@ func (s *TerminalRenderer) wrapCursor() {
 }
 
 func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
-	if cell != nil && cell.IsZero() {
+	if cell != nil && cell.Width == 0 {
 		// XXX: Zero width cells are special and should not be written to the
 		// screen no matter what other attributes they have.
 		// Zero width cells are used for wide characters that are split into
@@ -514,6 +514,14 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 	s.cur.X += cellWidth
 	if s.cur.X >= newbuf.Width() {
 		s.atPhantom = true
+	}
+
+	// For wide characters (width > 1), explicitly position the cursor to
+	// ensure we're in sync with terminals that may measure character width
+	// differently (e.g., iTerm2 uses wcwidth which measures some emojis as
+	// width 1 instead of 2).
+	if cellWidth > 1 && !s.atPhantom {
+		_, _ = s.buf.WriteString(ansi.CursorHorizontalAbsolute(s.cur.X + 1))
 	}
 }
 
@@ -578,8 +586,13 @@ func canClearWith(c *Cell) bool {
 	// NOTE: This assumes that the terminal supports bce terminfo capability
 	// which all xterm-compatible terminals and terminals that use xterm*
 	// terminal types do.
+	// We also need to check for foreground and background colors because
+	// EraseLineRight uses the current pen color, not the cell's color, and
+	// clearing cells with colors would lose the color information.
 	return c.Style.Underline == UnderlineNone &&
 		c.Style.Attrs&^(AttrBold|AttrFaint|AttrItalic|AttrBlink|AttrRapidBlink) == 0 &&
+		c.Style.Fg == nil &&
+		c.Style.Bg == nil &&
 		c.Link.IsZero()
 }
 

--- a/terminal_renderer_output_test.go
+++ b/terminal_renderer_output_test.go
@@ -2,6 +2,7 @@ package uv
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -143,6 +144,43 @@ func TestRendererOutput(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRendererWideCellReanchor(t *testing.T) {
+	render := func(grapheme bool) string {
+		var buf bytes.Buffer
+		s := NewTerminalRenderer(&buf, []string{
+			"TERM=xterm-256color",
+			"COLORTERM=truecolor",
+		})
+		s.SetFullscreen(true)
+		s.SetGraphemeWidth(grapheme)
+		s.SaveCursor()
+		s.Erase()
+
+		scr := NewScreenBuffer(10, 1)
+		buf.Reset()
+		NewStyledString("世界").Draw(scr, scr.Bounds())
+		s.Render(scr.RenderBuffer)
+		if err := s.Flush(); err != nil {
+			t.Fatalf("Flush failed: %v", err)
+		}
+		return buf.String()
+	}
+
+	out := render(false)
+	reanchors := strings.Count(out, "\x1b[5G")
+	if reanchors != 1 {
+		t.Errorf("non-grapheme line with wide cells: want 1 re-anchor, got %d in %q", reanchors, out)
+	}
+	if perCell := strings.Count(out, "\x1b[3G"); perCell != 0 {
+		t.Errorf("adjacent wide cells emitted a per-cell CHA: %q", out)
+	}
+
+	gout := render(true)
+	if n := strings.Count(gout, "\x1b[5G"); n != 0 {
+		t.Errorf("grapheme-mode line should not re-anchor, got %d in %q", n, gout)
 	}
 }
 

--- a/terminal_screen.go
+++ b/terminal_screen.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/colorprofile"
 	"github.com/charmbracelet/x/ansi"
@@ -37,6 +38,16 @@ type TerminalScreen struct {
 	windowTitle          string
 	syncUpdates          bool // mode 2026
 	resetTabs            bool // DECST8C - reset terminal tabs on start
+
+	// mu serializes access to the render buffer, output buffer, and
+	// width-method state so the terminal event loop (which negotiates
+	// grapheme-cluster width) cannot race with the application's own
+	// Render/Flush goroutine.
+	mu sync.Mutex
+	// widthMethodOverride is set when the application explicitly calls
+	// [TerminalScreen.SetWidthMethod]. An explicit override suppresses the
+	// automatic mode-2027 width-method negotiation.
+	widthMethodOverride bool
 }
 
 var _ Screen = (*TerminalScreen)(nil)
@@ -130,9 +141,53 @@ func (s *TerminalScreen) WidthMethod() WidthMethod {
 	return s.win.WidthMethod()
 }
 
-// SetWidthMethod sets the width method for the terminal screen.
+// SetWidthMethod sets the width method for the terminal screen. This is an
+// override that propagates to the window/buffer and the renderer so that all
+// width measurements use the same method. Calling this marks the width method
+// as explicitly overridden, which disables automatic mode-2027 negotiation.
 func (s *TerminalScreen) SetWidthMethod(method ansi.Method) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.widthMethodOverride = true
+	s.setWidthMethod(method)
+}
+
+// setWidthMethod propagates the width method to the window/buffer and the
+// renderer. Callers must hold s.mu.
+func (s *TerminalScreen) setWidthMethod(method ansi.Method) {
 	s.win.SetWidthMethod(method)
+	s.rend.SetWidthMethod(method)
+}
+
+// requestGraphemeWidth queues a DECRQM request for Unicode core mode (DEC mode
+// 2027) so the terminal reports whether it measures cell width using grapheme
+// clustering. The response arrives as a [ModeReportEvent].
+func (s *TerminalScreen) requestGraphemeWidth() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf.WriteString(ansi.RequestMode(ansi.ModeUnicodeCore))
+}
+
+// enableGraphemeWidth enables Unicode core mode (DEC mode 2027) on the terminal
+// and switches the screen's width method to [ansi.GraphemeWidth] so wide-glyph
+// measurement matches the terminal. The change propagates to the
+// window/buffer and renderer.
+//
+// If the application has explicitly set a width method via
+// [TerminalScreen.SetWidthMethod], the explicit choice is preserved and this is
+// a no-op. The change is committed to the underlying writer through the
+// screen's normal locked write path so it cannot race with Render/Flush.
+func (s *TerminalScreen) enableGraphemeWidth() {
+	s.mu.Lock()
+	if s.widthMethodOverride {
+		s.mu.Unlock()
+		return
+	}
+	s.buf.WriteString(ansi.SetMode(ansi.ModeUnicodeCore))
+	s.setWidthMethod(ansi.GraphemeWidth)
+	s.rend.SetGraphemeWidth(true)
+	s.mu.Unlock()
+	_ = s.Flush()
 }
 
 // SetColorProfile sets the color profile for the terminal screen.
@@ -173,6 +228,8 @@ func (s *TerminalScreen) Display(d Drawable) error {
 // The changes can be committed to the underlying writer by calling the
 // [TerminalScreen.Flush] method.
 func (s *TerminalScreen) Render() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for y := 0; y < s.win.Height(); y++ {
 		for x := 0; x < s.win.Width(); {
 			cell := s.win.CellAt(x, y)
@@ -194,6 +251,8 @@ func (s *TerminalScreen) Render() {
 
 // Flush writes any pending output to the underlying writer.
 func (s *TerminalScreen) Flush() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.cursor != nil && !s.cursor.Hidden && s.cursor.X >= 0 && s.cursor.Y >= 0 {
 		s.rend.MoveTo(s.cursor.X, s.cursor.Y)
 	} else if !s.altScreen {

--- a/widecell_placeholder_test.go
+++ b/widecell_placeholder_test.go
@@ -1,0 +1,54 @@
+package uv
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestStyledWideCellPlaceholderDetection reproduces the placeholder-detection
+// inconsistency introduced by PR #124.
+//
+// Line.Set marks the continuation columns of a wide cell with Width == 0
+// placeholders. The PR makes those placeholders inherit the wide cell's Style
+// and Link. The renderer detects placeholders two different ways:
+//
+//   - putAttrCell (terminal_renderer.go:490) uses cell.Width == 0
+//   - putRange / transformLine (terminal_renderer.go:694,942,950) use IsZero()
+//
+// For an unstyled wide cell both agree, because the placeholder equals Cell{}.
+// For a styled wide cell the placeholder is no longer zero, so IsZero() stops
+// recognizing it while Width == 0 still does. The two checks disagree, which is
+// how transformLine can pick a move/insert point inside a wide glyph.
+func TestStyledWideCellPlaceholderDetection(t *testing.T) {
+	t.Run("unstyled wide cell: both checks agree", func(t *testing.T) {
+		l := make(Line, 5)
+		l.Set(0, &Cell{Content: "你", Width: 2})
+
+		ph := l.At(1)
+		if ph.Width != 0 {
+			t.Fatalf("expected placeholder Width == 0, got %d", ph.Width)
+		}
+		if !ph.IsZero() {
+			t.Errorf("expected unstyled placeholder to be IsZero()")
+		}
+	})
+
+	t.Run("styled wide cell: checks disagree (regression)", func(t *testing.T) {
+		l := make(Line, 5)
+		l.Set(0, &Cell{Content: "你", Width: 2, Style: Style{Bg: ansi.Red}})
+
+		ph := l.At(1)
+		if ph.Width != 0 {
+			t.Fatalf("expected placeholder Width == 0, got %d", ph.Width)
+		}
+		// This is the bug: the Width==0 placeholder is no longer IsZero(), so
+		// every renderer path still keyed on IsZero() fails to skip it.
+		if ph.IsZero() {
+			t.Skip("placeholder is zero; PR #124 style inheritance not present")
+		}
+		t.Errorf("styled wide-cell placeholder has Width==0 but IsZero()==false: "+
+			"renderer paths using IsZero() (terminal_renderer.go:694,942,950) "+
+			"will not recognize it; placeholder=%+v", *ph)
+	})
+}


### PR DESCRIPTION
Editor's note: this is primarily an emoji-specific patch.

***

## Summary

Wide characters (notably emojis) could render with incorrect background colors and leave the cursor out of sync on terminals that measure character width differently than ultraviolet does. This PR fixes the rendering of wide cells end to end.

## Changes

- **Placeholder cells inherit style** — wide-cell placeholder cells now inherit `Style` and `Link` from the parent cell so background colors render across the full glyph instead of only its first column.
- **Zero-width detection via `Width == 0`** — `putAttrCell` now detects zero-width placeholder cells using `cell.Width == 0` instead of `cell.IsZero()`, so styled placeholders are still correctly skipped during rendering.
- **Cursor resync after wide chars** — after emitting a wide character, the renderer explicitly repositions the cursor with `CHA` (Cursor Horizontal Absolute) to stay in sync with terminals such as iTerm2 that use `wcwidth` and measure some emojis as width 1 instead of 2.
- **`canClearWith` respects colors** — clearing commands no longer erase cells carrying foreground or background colors, since erase sequences use the current pen color and would otherwise drop the cell's color information.

## Testing

- `go build ./...`
- `go test ./...` — all packages pass.

## Notes

These fixes have been running in production in a downstream fork; opening here (as a draft) to upstream them. Happy to add focused regression tests or split the commit if preferred.
