### PR TITLE
fix: realign cursor after writing multi-byte cells

### DIFF
--- a/examples/multibyte/main.go
+++ b/examples/multibyte/main.go
@@ -1,0 +1,93 @@
+// Renders a dense grid of multi-byte glyphs (wide emoji, ZWJ sequences and
+// variation-selector clusters) framed by '|' borders on both sides of every
+// row. The borders only stay aligned if the terminal and renderer agree on how
+// far the cursor advances after each multi-byte cell.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/ultraviolet/screen"
+)
+
+var emojis = []string{
+	"🫩", "🫆", "🫜", "🪾", "🪉", "🪏", "🫠", "🫡", "🫨", "🥹",
+	"🫥", "🫢", "🫣", "🫤", "🫷", "🫸", "🫎", "🫏", "🪽", "🪿",
+	"🪼", "🫛", "🫚", "🪭", "🪮", "🪇", "🩷", "🩵", "🩶", "🐦‍🔥",
+	"🍋‍🟩", "🍄‍🟫", "🙂‍↔️", "🙂‍↕️", "☹️", "❤️", "✈️", "☀️", "⛓️‍💥",
+}
+
+func main() {
+	t := uv.DefaultTerminal()
+	if err := run(t); err != nil {
+		log.Fatalf("error: %v", err)
+	}
+}
+
+func run(t *uv.Terminal) error {
+	scr := t.Screen()
+	scr.EnterAltScreen()
+	scr.SetSynchronizedUpdates(true)
+
+	if err := t.Start(); err != nil {
+		return err
+	}
+	defer t.Stop()
+
+	if w, h, err := t.GetSize(); err == nil {
+		scr.Resize(w, h)
+	}
+	display(scr)
+	defer display(scr)
+
+	for ev := range t.Events() {
+		switch ev := ev.(type) {
+		case uv.WindowSizeEvent:
+			scr.Resize(ev.Width, ev.Height)
+			display(scr)
+		case uv.KeyPressEvent:
+			if ev.MatchString("q") || ev.MatchString("ctrl+c") || ev.MatchString("esc") {
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func display(scr *uv.TerminalScreen) {
+	screen.Clear(scr)
+	ctx := screen.NewContext(scr)
+	bounds := scr.Bounds()
+	width := bounds.Dx()
+	if width <= 0 {
+		return
+	}
+
+	for y := range bounds.Dy() {
+		drawRow(scr, ctx, y, width)
+	}
+
+	scr.Render()
+	scr.Flush()
+}
+
+func drawRow(scr *uv.TerminalScreen, ctx *screen.Context, y, width int) {
+	prefix := fmt.Sprintf("%2d |", y)
+	ctx.DrawString(prefix, 0, y)
+
+	x := scr.WidthMethod().StringWidth(prefix)
+	for i := 0; x < width-1; i++ {
+		emoji := emojis[(y*17+i)%len(emojis)]
+		w := scr.WidthMethod().StringWidth(emoji)
+		if x+w > width-1 {
+			break
+		}
+		ctx.DrawString(emoji, x, y)
+		x += w
+	}
+
+	ctx.DrawString("|", width-1, y)
+}

--- a/examples/sidebar/main.go
+++ b/examples/sidebar/main.go
@@ -1,0 +1,144 @@
+// Mimics a chat TUI like docker-agent: a left "conversation" pane full of
+// emoji, a vertical separator, and a right sidebar. The separator is drawn at a
+// fixed column on every row. It only stays straight if the terminal and the
+// renderer agree on how far the cursor advances after each multi-byte emoji
+// cell. Without the cursor realignment fix, the separator (and the whole
+// sidebar) drifts left or right on rows that contain wide or ZWJ emoji.
+//
+// Press 'r' to redraw with a fresh set of emoji, 'q' to quit.
+package main
+
+import (
+	"log"
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/ultraviolet/screen"
+)
+
+// A mix of wide emoji, ZWJ sequences and variation-selector clusters. These are
+// exactly the kind of multi-byte/multi-rune cells that desync the cursor.
+var emojis = []string{
+	"🫩", "🫆", "🫜", "🪾", "🪉", "🫠", "🫡", "🫨", "🥹", "🐦‍🔥",
+	"🍋‍🟩", "🍄‍🟫", "🙂‍↔️", "☹️", "❤️", "✈️", "⛓️‍💥", "🩷", "🩵", "🩶",
+}
+
+// Short fake chat lines; %s slots are filled with emoji.
+var chatLines = []string{
+	"user: ship it %s %s",
+	"agent: building the image %s",
+	"agent: running tests %s %s %s",
+	"agent: all green %s done %s",
+	"user: nice %s",
+	"agent: pushing %s to the registry %s",
+}
+
+const sidebarWidth = 24
+
+func main() {
+	t := uv.DefaultTerminal()
+	if err := run(t); err != nil {
+		log.Fatalf("error: %v", err)
+	}
+}
+
+func run(t *uv.Terminal) error {
+	scr := t.Screen()
+	scr.EnterAltScreen()
+	scr.SetSynchronizedUpdates(true)
+
+	if err := t.Start(); err != nil {
+		return err
+	}
+	defer t.Stop()
+
+	if w, h, err := t.GetSize(); err == nil {
+		scr.Resize(w, h)
+	}
+
+	offset := 0
+	display(scr, offset)
+	defer display(scr, offset)
+
+	for ev := range t.Events() {
+		switch ev := ev.(type) {
+		case uv.WindowSizeEvent:
+			scr.Resize(ev.Width, ev.Height)
+			display(scr, offset)
+		case uv.KeyPressEvent:
+			switch {
+			case ev.MatchString("q"), ev.MatchString("ctrl+c"), ev.MatchString("esc"):
+				return nil
+			case ev.MatchString("r"):
+				offset++
+				display(scr, offset)
+			}
+		}
+	}
+
+	return nil
+}
+
+func display(scr *uv.TerminalScreen, offset int) {
+	screen.Clear(scr)
+	ctx := screen.NewContext(scr)
+
+	bounds := scr.Bounds()
+	width, height := bounds.Dx(), bounds.Dy()
+	if width < sidebarWidth+10 || height < 1 {
+		return
+	}
+
+	// The separator sits just left of the sidebar, at a fixed column.
+	sepX := width - sidebarWidth - 1
+
+	for y := range height {
+		drawChatRow(scr, ctx, y, sepX, offset)
+		ctx.DrawString("│", sepX, y)
+		drawSidebarRow(ctx, y, sepX+2)
+	}
+
+	scr.Render()
+	scr.Flush()
+}
+
+// drawChatRow fills the left pane with an emoji-laden chat line, cropped so it
+// never reaches the separator column.
+func drawChatRow(scr *uv.TerminalScreen, ctx *screen.Context, y, sepX, offset int) {
+	tmpl := chatLines[(y+offset)%len(chatLines)]
+	text := buildChatLine(tmpl, y+offset)
+	// Crop to the available width before the separator.
+	for scr.StringWidth(text) > sepX-1 && len(text) > 0 {
+		text = text[:len(text)-1]
+	}
+	ctx.DrawString(text, 0, y)
+}
+
+// buildChatLine fills the %s slots of tmpl with emoji picked from seed.
+func buildChatLine(tmpl string, seed int) string {
+	parts := strings.Split(tmpl, "%s")
+	var b strings.Builder
+	for i, p := range parts {
+		b.WriteString(p)
+		if i < len(parts)-1 {
+			b.WriteString(emojis[(seed+i)%len(emojis)])
+		}
+	}
+	return b.String()
+}
+
+// drawSidebarRow draws a stable, emoji-free sidebar so any wobble is obviously
+// caused by the left pane's emoji, not the sidebar content.
+func drawSidebarRow(ctx *screen.Context, y, x int) {
+	rows := []string{
+		" Session",
+		" ─────────",
+		" model:  gpt",
+		" tokens: 1234",
+		" tools:  7",
+		" status: ready",
+	}
+	if y < len(rows) {
+		ctx.DrawString(rows[y], x, y)
+	}
+}

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -515,6 +515,10 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 	if s.cur.X >= newbuf.Width() {
 		s.atPhantom = true
 	}
+
+	if cell != nil && len(cell.Content) > 1 && !s.atPhantom {
+		_, _ = s.buf.WriteString(ansi.CursorHorizontalAbsolute(s.cur.X + 1))
+	}
 }
 
 // putCellLR draws a cell at the lower right corner of the screen.


### PR DESCRIPTION
After emitting a cell whose content spans more than one byte (wide characters and multi-rune grapheme clusters), terminals can disagree with the renderer about how far the cursor advanced. Emit an explicit CursorHorizontalAbsolute to the expected column so the terminal's cursor stays in sync with our tracked position, unless we're at the phantom (pending-wrap) cell where moving would prematurely cancel the wrap.

Adds two examples that reproduce the issue: a dense multi-byte glyph grid and a chat-style layout with a vertical separator and sidebar.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
