### PR TITLE
fix(render): flush trailing empty cells in renderLine

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -187,6 +187,9 @@ func renderLine(buf io.StringWriter, l Line) {
 		_, _ = buf.WriteString(c.String())
 	}
 
+	if pending.Len() > 0 {
+		_, _ = buf.WriteString(pending.String())
+	}
 	if link.URL != "" {
 		_, _ = buf.WriteString(ansi.ResetHyperlink())
 	}

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -656,6 +656,48 @@ func TestLineRenderLine(t *testing.T) {
 	}
 }
 
+func TestRenderLinePreservesTrailingSpaces(t *testing.T) {
+	// renderLine should preserve trailing empty cells as spaces.
+	// A line of width 10 with "Hi" at positions 0-1 and empty cells at 2-9
+	// should render all 10 visible characters: "Hi" followed by 8 spaces.
+	l := NewLine(10)
+	l[0] = Cell{Content: "H", Width: 1}
+	l[1] = Cell{Content: "i", Width: 1}
+	// Positions 2-9 remain EmptyCell (space, width 1, no style)
+
+	output := l.Render()
+
+	// Strip any ANSI sequences to count visible characters.
+	visible := ansi.Strip(output)
+	if len(visible) != 10 {
+		t.Errorf("Render() produced %d visible chars, want 10; output=%q visible=%q",
+			len(visible), output, visible)
+	}
+}
+
+func TestRenderLinePreservesStyledTrailingSpaces(t *testing.T) {
+	// When trailing cells have explicit styling (e.g. background color),
+	// renderLine must emit them with their ANSI attributes, not drop them.
+	l := NewLine(5)
+	l[0] = Cell{Content: "A", Width: 1}
+	// Positions 1-4: spaces with a red background.
+	for i := 1; i < 5; i++ {
+		l[i] = Cell{Content: " ", Width: 1, Style: Style{Bg: ansi.Red}}
+	}
+
+	output := l.Render()
+
+	visible := ansi.Strip(output)
+	if len(visible) != 5 {
+		t.Errorf("Render() produced %d visible chars, want 5; output=%q visible=%q",
+			len(visible), output, visible)
+	}
+	// The output must contain a background color sequence for the trailing spaces.
+	if !strings.Contains(output, "41") { // SGR 41 = red background
+		t.Errorf("Render() missing red background SGR for trailing styled spaces; output=%q", output)
+	}
+}
+
 func BenchmarkBufferSetCell(b *testing.B) {
 	buf := NewBuffer(80, 24)
 	cell := &Cell{Content: "A", Width: 1}

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -692,9 +692,36 @@ func TestRenderLinePreservesStyledTrailingSpaces(t *testing.T) {
 		t.Errorf("Render() produced %d visible chars, want 5; output=%q visible=%q",
 			len(visible), output, visible)
 	}
-	// The output must contain a background color sequence for the trailing spaces.
-	if !strings.Contains(output, "41") { // SGR 41 = red background
-		t.Errorf("Render() missing red background SGR for trailing styled spaces; output=%q", output)
+	// The output must contain the background color sequence for the trailing
+	// spaces. Derive the expected sequence from the style itself rather than
+	// hardcoding an SGR number.
+	red := Style{Bg: ansi.Red}
+	wantSeq := red.Diff(&Style{})
+	if !strings.Contains(output, wantSeq) {
+		t.Errorf("Render() missing background SGR %q for trailing styled spaces; output=%q", wantSeq, output)
+	}
+}
+
+func TestRenderLineWideCellTail(t *testing.T) {
+	// A line ending in a wide cell's continuation column (a zero cell) must
+	// not disturb pending empty cells: the zero cell is skipped, and the
+	// buffered spaces are still flushed at end of line.
+	l := NewLine(6)
+	l[0] = Cell{Content: "A", Width: 1}
+	// Positions 1-3 remain EmptyCell.
+	l[4] = Cell{Content: "你", Width: 2}
+	l[5] = Cell{} // continuation column of the wide cell
+
+	output := l.Render()
+
+	visible := ansi.Strip(output)
+	// "A", 3 buffered spaces, then the wide grapheme. The continuation
+	// column contributes nothing.
+	if want := "A   你"; visible != want {
+		t.Errorf("Render() = %q, want %q; output=%q", visible, want, output)
+	}
+	if w := uniseg.StringWidth(visible); w != 6 {
+		t.Errorf("Render() visible width = %d, want 6; output=%q", w, output)
 	}
 }
 


### PR DESCRIPTION
I discovered this issue when background colors on otherwise empty cells were missing. Three line change plus TDD tests.

*AI generated, but human edited, PR description follows*
<hr/>

`renderLine()` silently drops trailing empty cells. It accumulates them in a `pending` buffer that is flushed when a non-empty cell follows, but at end-of-line the pending buffer is discarded. This is a three-line fix: flush `pending` before the style/link resets at the end of the function.

`Render()` on a 10-cell line containing "Hi" produces `"Hi"` (2 visible chars) instead of `"Hi        "` (10 visible chars). This breaks any consumer that expects `Render()` output to faithfully represent the full line width — layout, copy/paste, width calculations, and screen change detection all see truncated lines.

`Line.String()` intentionally trims trailing spaces (documented: "Any trailing spaces are removed"), but `Render()` has no such contract. _Does that apply here too? Doesn't seem like it. LMK_

   ## Changes

  - **buffer.go**: 3 lines added — flush `pending` at end of `renderLine()` before resetting styles/links
  - **buffer_test.go**: Two new tests:
  - `TestRenderLinePreservesTrailingSpaces` — proves a 10-wide line with "Hi" at positions 0-1 renders 10 visible characters, not 2
  - `TestRenderLinePreservesStyledTrailingSpaces` — proves trailing cells with explicit background color preserve their ANSI attributes
   
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] Not Applicable - ~I have created a discussion that was approved by a maintainer (for new features).~
