### PR TITLE
perf: add DrawOver and HardScroll for incremental scroll rendering

### DIFF
--- a/styled.go
+++ b/styled.go
@@ -61,6 +61,21 @@ func (s *StyledString) Draw(buf Screen, area Rectangle) {
 	printString(buf, buf.WidthMethod(), area.Min.X, area.Min.Y, area, str, !s.Wrap, s.Tail)
 }
 
+// DrawOver renders the styled string to the given buffer at the specified area
+// WITHOUT clearing the area first. Cells that haven't changed (as determined
+// by SetCell's equality check) will not be marked as touched, enabling
+// incremental rendering.
+//
+// Use DrawOver instead of Draw when the buffer already contains a previous
+// frame's content and you want to minimise touched-line tracking for the
+// terminal renderer's diff algorithm. The caller is responsible for clearing
+// any trailing cells that the new content does not reach.
+func (s *StyledString) DrawOver(buf Screen, area Rectangle) {
+	str := s.Text
+	str = strings.ReplaceAll(str, "\r\n", "\n")
+	printString(buf, buf.WidthMethod(), area.Min.X, area.Min.Y, area, str, !s.Wrap, s.Tail)
+}
+
 // Height returns the number of lines in the styled string. This is the number
 // of lines that the styled string will occupy when rendered to the screen.
 func (s *StyledString) Height() int {

--- a/styled_drawover_test.go
+++ b/styled_drawover_test.go
@@ -1,0 +1,51 @@
+package uv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDrawOverMatchesDraw(t *testing.T) {
+	const w, h = 80, 24
+	content := strings.Repeat("Hello, World! \x1b[1mBold\x1b[0m normal\n", h-1) + "last line"
+	s := NewStyledString(content)
+	area := Rect(0, 0, w, h)
+
+	buf1 := NewScreenBuffer(w, h)
+	s.Draw(buf1, area)
+
+	buf2 := NewScreenBuffer(w, h)
+	s.DrawOver(buf2, area)
+
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			c1 := buf1.CellAt(x, y)
+			c2 := buf2.CellAt(x, y)
+			if !cellEqual(c1, c2) {
+				t.Errorf("cell mismatch at (%d, %d): Draw=%+v DrawOver=%+v", x, y, c1, c2)
+			}
+		}
+	}
+}
+
+func TestDrawOverIncrementalTouch(t *testing.T) {
+	const w, h = 80, 10
+	content := strings.Repeat("Same line content here\n", h-1) + "Same line content here"
+	s := NewStyledString(content)
+	area := Rect(0, 0, w, h)
+
+	buf := NewScreenBuffer(w, h)
+	// Populate the buffer with the first draw.
+	s.DrawOver(buf, area)
+
+	// Reset touched tracking to simulate start of a new frame.
+	buf.Touched = make([]*LineData, h)
+
+	// DrawOver with identical content should not touch any lines.
+	s.DrawOver(buf, area)
+
+	touched := buf.TouchedLines()
+	if touched != 0 {
+		t.Errorf("DrawOver with identical content touched %d lines, expected 0", touched)
+	}
+}

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -145,6 +145,7 @@ type TerminalRenderer struct {
 	caps             capabilities // terminal control sequence capabilities
 	atPhantom        bool         // whether the cursor is out of bounds and at a phantom cell
 	lineHadWide      bool         // whether the line currently being transformed contained a wide cell
+	skipScrollOptim  bool         // set by HardScroll to skip scrollOptimize on the next Render call
 	logger           Logger       // The logger used for debugging.
 
 	// profile is the color profile to use when downsampling colors. This is
@@ -1241,12 +1242,13 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 		// misbehaves and moves the cursor outside of the scrolling region. For
 		// now, we disable the optimizations completely on Windows.
 		// See https://github.com/microsoft/terminal/issues/19016
-		if s.flags.Contains(tScrollOptim) && s.flags.Contains(tFullscreen) {
+		if s.flags.Contains(tScrollOptim) && s.flags.Contains(tFullscreen) && !s.skipScrollOptim {
 			// Optimize scrolling for the alternate screen buffer.
 			// TODO: Should we optimize for inline mode as well? If so, we need
 			// to know the actual cursor position to use [ansi.DECSTBM].
 			s.scrollOptimize(newbuf)
 		}
+		s.skipScrollOptim = false
 
 		var changedLines int
 		var i int

--- a/terminal_renderer_hardscroll.go
+++ b/terminal_renderer_hardscroll.go
@@ -241,3 +241,21 @@ func (s *TerminalRenderer) scrollIdl(newbuf *RenderBuffer, n, del, ins int, blan
 
 	return true
 }
+
+// HardScroll scrolls lines [top, bot] by n positions using terminal scroll
+// region sequences, then shifts curbuf to match. Positive n = content moves
+// up (new lines appear at bottom). Returns true if the terminal accepted the
+// scroll. Caller must ensure cellbuf is already shifted to match.
+//
+// When HardScroll succeeds, scrollOptimize is skipped on the next Render call
+// because the scroll has already been handled.
+func (s *TerminalRenderer) HardScroll(newbuf *RenderBuffer, n, top, bot int) bool {
+	if s.curbuf == nil || !s.flags.Contains(tFullscreen) {
+		return false
+	}
+	ok := s.scrolln(newbuf, n, top, bot, newbuf.Height()-1)
+	if ok {
+		s.skipScrollOptim = true
+	}
+	return ok
+}


### PR DESCRIPTION
Closes #129

## Summary

Adds two public APIs to support incremental scroll rendering in bubbletea v2:

- `StyledString.DrawOver(buf, area)` — renders without pre-clearing, enabling
  touched-line tracking via SetCell equality check
- `TerminalRenderer.HardScroll(newbuf, n, top, bot)` — directly emits terminal
  scroll sequences via existing `scrolln` and skips `scrollOptimize` on next Render

## Changes

- `styled.go`: new `DrawOver` method (mirrors `Draw` minus the clear loop)
- `styled_drawover_test.go`: output equivalence + incremental touch tests
- `terminal_renderer.go`: `skipScrollOptim` field + guard in `Render()`
- `terminal_renderer_hardscroll.go`: public `HardScroll` method

## Motivation

bubbletea v2's cursedRenderer scroll frames cost ~800µs vs v1's ~100µs. The
bottleneck is redundant work: full ANSI reparse + O(width×height) hashmap
re-detection of scrolls that the caller already knows about. These APIs let
the caller bypass both.

Companion bubbletea PR: https://github.com/charmbracelet/bubbletea/pull/1725
