### PR TITLE
fix(renderer): re-anchor and repaint drift-prone lines more precisely

### DIFF
--- a/examples/advanced/boxes/main.go
+++ b/examples/advanced/boxes/main.go
@@ -383,35 +383,33 @@ func (a *App) Run(input uv.File, output uv.File, environ []string) error {
 	scr.SetMouseMode(uv.MouseModeDrag)
 
 	for !a.quit {
-		select {
-		case ev := <-term.Events():
-			log.Printf("event: %#v", ev)
+		ev := <-term.Events()
+		log.Printf("event: %#v", ev)
 
-			switch ev := ev.(type) {
-			case uv.WindowSizeEvent:
-				// We need to update our terminal size and root window size.
-				scr.Resize(ev.Width, ev.Height)
-				a.root.Resize(ev.Width, ev.Height)
-			}
+		switch ev := ev.(type) {
+		case uv.WindowSizeEvent:
+			// We need to update our terminal size and root window size.
+			scr.Resize(ev.Width, ev.Height)
+			a.root.Resize(ev.Width, ev.Height)
+		}
 
-			focusedID := a.ActiveID()
-			if len(focusedID) == 0 {
-				// Ignore events if no window is focused.
-				continue
-			}
+		focusedID := a.ActiveID()
+		if len(focusedID) == 0 {
+			// Ignore events if no window is focused.
+			continue
+		}
 
-			for !a.HandleEvent(focusedID, ev) {
-				if parentID := a.ParentID(focusedID); parentID != "" {
-					log.Printf("event not handled by %q, passing to parent %q", focusedID, parentID)
-					focusedID = parentID
-				} else {
-					break
-				}
+		for !a.HandleEvent(focusedID, ev) {
+			if parentID := a.ParentID(focusedID); parentID != "" {
+				log.Printf("event not handled by %q, passing to parent %q", focusedID, parentID)
+				focusedID = parentID
+			} else {
+				break
 			}
+		}
 
-			if err := scr.Display(a); err != nil {
-				return fmt.Errorf("failed to display terminal: %w", err)
-			}
+		if err := scr.Display(a); err != nil {
+			return fmt.Errorf("failed to display terminal: %w", err)
 		}
 	}
 

--- a/examples/advanced/image/main.go
+++ b/examples/advanced/image/main.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"time"
 
 	_ "image/jpeg" // Register JPEG format
 
@@ -295,17 +294,19 @@ func main() {
 					})
 				}
 			}
-
 		}
 
 		scr.Render() //nolint:errcheck
 		scr.Flush()
 	}
 
+	// Window operation 14 requests the window size in pixels.
+	const requestWindowSizeWinOp = 14
+
 	// Query image encoding support.
-	scr.WriteString(ansi.RequestPrimaryDeviceAttributes)        // Query Sixel support.
-	scr.WriteString(ansi.RequestNameVersion)                    // Query terminal version and name.
-	scr.WriteString(ansi.WindowOp(ansi.RequestWindowSizeWinOp)) // Request window size.
+	scr.WriteString(ansi.RequestPrimaryDeviceAttributes)   // Query Sixel support.
+	scr.WriteString(ansi.RequestNameVersion)               // Query terminal version and name.
+	scr.WriteString(ansi.WindowOp(requestWindowSizeWinOp)) // Request window size.
 	// Query Kitty Graphics support using random id=31.
 	scr.WriteString(ansi.KittyGraphics([]byte("AAAA"), "i=31", "s=1", "v=1", "a=q", "t=d", "f=24"))
 
@@ -391,9 +392,6 @@ LOOP:
 			}
 		}
 	}
-
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 
 	// Disable mouse support.
 	scr.WriteString(ansi.ResetMode(

--- a/examples/advanced/splits/main.go
+++ b/examples/advanced/splits/main.go
@@ -143,12 +143,12 @@ Note: constraint labels that don't fit are truncated`
 		{
 			"Ratio",
 			[]layout.Constraint{
-				layout.Ratio{0, 4},
-				layout.Ratio{1, 4},
-				layout.Ratio{2, 4},
-				layout.Ratio{3, 4},
-				layout.Ratio{4, 4},
-				layout.Ratio{6, 4},
+				layout.Ratio{Num: 0, Den: 4},
+				layout.Ratio{Num: 1, Den: 4},
+				layout.Ratio{Num: 2, Den: 4},
+				layout.Ratio{Num: 3, Den: 4},
+				layout.Ratio{Num: 4, Den: 4},
+				layout.Ratio{Num: 6, Den: 4},
 			},
 		},
 	}

--- a/examples/draw/main.go
+++ b/examples/draw/main.go
@@ -26,9 +26,9 @@ func main() {
 	defer t.Stop()
 
 	modes := []ansi.Mode{
-		ansi.ButtonEventMouseMode,
-		ansi.SgrExtMouseMode,
-		ansi.FocusEventMode,
+		ansi.ModeMouseButtonEvent,
+		ansi.ModeMouseExtSgr,
+		ansi.ModeFocusEvent,
 	}
 
 	scr.WriteString(ansi.SetMode(modes...))

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/mosaic v0.0.0-20250509021451-13796e822d86
 	github.com/charmbracelet/x/term v0.2.2
+	github.com/clipperhouse/uax29/v2 v2.7.0
 	github.com/lucasb-eyer/go-colorful v1.4.0
 	github.com/mattn/go-runewidth v0.0.23
 	github.com/rivo/uniseg v0.4.7
@@ -21,7 +22,6 @@ require (
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
-	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/image v0.32.0 // indirect

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/mosaic v0.0.0-20250509021451-13796e822d86
 	github.com/charmbracelet/x/term v0.2.2
+	github.com/clipperhouse/uax29/v2 v2.7.0
 	github.com/lucasb-eyer/go-colorful v1.4.1
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/rivo/uniseg v0.4.7
@@ -21,7 +22,6 @@ require (
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
-	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/image v0.32.0 // indirect

--- a/examples/sidebar/main.go
+++ b/examples/sidebar/main.go
@@ -1,0 +1,139 @@
+// Mimics a chat TUI: a left "conversation" pane full of
+// emoji, a vertical separator, and a right sidebar. The separator is drawn at a
+// fixed column on every row. It only stays straight if the terminal and the
+// renderer agree on how far the cursor advances after each multi-byte emoji
+// cell.
+//
+// Press 'r' to redraw with a fresh set of emoji, 'q' to quit.
+package main
+
+import (
+	"log"
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/ultraviolet/screen"
+	"github.com/clipperhouse/uax29/v2/graphemes"
+)
+
+// A mix of wide emoji, ZWJ sequences and variation-selector clusters. These are
+// exactly the kind of multi-byte/multi-rune cells that desync the cursor.
+var emojis = []string{
+	"🫩", "🫆", "🫜", "🪾", "🪉", "🫠", "🫡", "🫨", "🥹", "🐦‍🔥",
+	"🍋‍🟩", "🍄‍🟫", "🙂‍↔️", "☹️", "❤️", "✈️", "⛓️‍💥", "🩷", "🩵", "🩶",
+	"⚠️",
+}
+
+// Short fake chat lines; %s slots are filled with emoji.
+var chatLines = []string{
+	"user: ship it %s %s",
+	"agent: building the image %s",
+	"agent: running tests %s %s %s",
+	"agent: all green %s done %s",
+	"user: nice %s",
+	"agent: pushing %s to the registry %s",
+}
+
+const sidebarWidth = 24
+
+func main() {
+	t := uv.DefaultTerminal()
+	if err := run(t); err != nil {
+		log.Fatalf("error: %v", err)
+	}
+}
+
+func run(t *uv.Terminal) error {
+	scr := t.Screen()
+	scr.EnterAltScreen()
+	scr.SetSynchronizedUpdates(true)
+
+	if err := t.Start(); err != nil {
+		return err
+	}
+	defer t.Stop()
+
+	if w, h, err := t.GetSize(); err == nil {
+		scr.Resize(w, h)
+	}
+
+	offset := 0
+	display(scr, offset)
+	defer display(scr, offset)
+
+	for ev := range t.Events() {
+		switch ev := ev.(type) {
+		case uv.WindowSizeEvent:
+			scr.Resize(ev.Width, ev.Height)
+			display(scr, offset)
+		case uv.KeyPressEvent:
+			switch {
+			case ev.MatchString("q"), ev.MatchString("ctrl+c"), ev.MatchString("esc"):
+				return nil
+			case ev.MatchString("r"):
+				offset++
+				display(scr, offset)
+			}
+		}
+	}
+
+	return nil
+}
+
+func display(scr *uv.TerminalScreen, offset int) {
+	screen.Clear(scr)
+	ctx := screen.NewContext(scr)
+
+	bounds := scr.Bounds()
+	width, height := bounds.Dx(), bounds.Dy()
+	if width < sidebarWidth+10 || height < 1 {
+		return
+	}
+
+	// The separator sits just left of the sidebar, at a fixed column.
+	sepX := width - sidebarWidth - 1
+
+	for y := range height {
+		drawChatRow(scr, ctx, y, sepX, offset)
+		ctx.DrawString("│", sepX, y)
+	}
+
+	scr.Render()
+	scr.Flush()
+}
+
+// drawChatRow fills the left pane with an emoji-laden chat line, cropped so it
+// never reaches the separator column.
+func drawChatRow(scr *uv.TerminalScreen, ctx *screen.Context, y, sepX, offset int) {
+	tmpl := chatLines[(y+offset)%len(chatLines)]
+	text := buildChatLine(tmpl, y+offset)
+	ctx.DrawString(cropToWidth(scr, text, sepX-1), 0, y)
+}
+
+// cropToWidth crops text to at most maxWidth columns, dropping whole grapheme
+// clusters. Cropping runes instead could turn a ZWJ or variation-selector
+// emoji into a different character (e.g. "\u2639\ufe0f" into "\u2639").
+func cropToWidth(scr *uv.TerminalScreen, text string, maxWidth int) string {
+	width := 0
+	gr := graphemes.FromString(text)
+	for gr.Next() {
+		width += scr.StringWidth(gr.Value())
+		if width > maxWidth {
+			return text[:gr.Start()]
+		}
+	}
+	return text
+}
+
+// buildChatLine fills the %s slots of tmpl with emoji picked from seed.
+func buildChatLine(tmpl string, seed int) string {
+	parts := strings.Split(tmpl, "%s")
+	var b strings.Builder
+	for i, p := range parts {
+		b.WriteString(p)
+		if i < len(parts)-1 {
+			b.WriteString(emojis[(seed+i)%len(emojis)])
+		}
+	}
+	return b.String()
+}

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -6,6 +6,7 @@ import (
 	"hash/maphash"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/colorprofile"
 	"github.com/charmbracelet/x/ansi"
@@ -556,9 +557,16 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 		s.atPhantom = true
 	}
 
-	if cellWidth > 1 && !s.flags.Contains(tGraphemeWidth) {
+	if cell != nil && !s.flags.Contains(tGraphemeWidth) && cellMayDrift(cell) {
 		s.wideDrift = true
 	}
+}
+
+// cellMayDrift reports whether drawing the cell may desync the terminal's
+// cursor column from ours on terminals without mode 2027: legacy width tables
+// measure wide glyphs and multi-rune clusters (VS16/ZWJ sequences) differently.
+func cellMayDrift(cell *Cell) bool {
+	return cell.Width > 1 || utf8.RuneCountInString(cell.Content) > 1
 }
 
 // reanchor emits an absolute horizontal move when the terminal's cursor
@@ -1465,8 +1473,8 @@ func relativeCursorMove(s *TerminalRenderer, newbuf *RenderBuffer, fx, fy, tx, t
 					cell := newbuf.CellAt(fx+i, ty)
 					if cell != nil && cell.Width > 0 {
 						i += cell.Width - 1
-						if cell.Width > 1 && !s.flags.Contains(tGraphemeWidth) {
-							// Overwriting wide glyphs drifts the cursor on
+						if !s.flags.Contains(tGraphemeWidth) && cellMayDrift(cell) {
+							// Overwriting these cells drifts the cursor on
 							// terminals without mode 2027.
 							overwrite = false
 							break

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -144,7 +144,7 @@ type TerminalRenderer struct {
 	clear            bool         // whether to force clear the screen
 	caps             capabilities // terminal control sequence capabilities
 	atPhantom        bool         // whether the cursor is out of bounds and at a phantom cell
-	lineHadWide      bool         // whether the line currently being transformed contained a wide cell
+	wideDrift        bool         // whether the terminal cursor column may have drifted after a wide glyph
 	logger           Logger       // The logger used for debugging.
 
 	// profile is the color profile to use when downsampling colors. This is
@@ -435,6 +435,13 @@ func (s *TerminalRenderer) move(newbuf *RenderBuffer, x, y int) {
 		s.cur.X = 0
 		_ = s.buf.WriteByte('\r')
 		s.atPhantom = false // reset phantom cell state
+		s.wideDrift = false // CR lands on a known column
+	} else if s.wideDrift {
+		// The terminal's column may disagree with ours after wide glyphs. CR
+		// re-anchors the column so the movement below stays exact.
+		s.cur.X = 0
+		_ = s.buf.WriteByte('\r')
+		s.wideDrift = false
 	}
 
 	// TODO: Investigate if we need to handle this case and/or if we need the
@@ -529,6 +536,12 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 		s.atPhantom = false
 	}
 
+	if cell == nil || cell.Width == 1 {
+		// A narrow cell must land on its exact column, so fix any drift left
+		// behind by preceding wide glyphs first.
+		s.reanchor()
+	}
+
 	s.updatePen(cell)
 	cellWidth := 1
 	if cell == nil {
@@ -543,9 +556,26 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 		s.atPhantom = true
 	}
 
-	if cellWidth > 1 {
-		s.lineHadWide = true
+	if cellWidth > 1 && !s.flags.Contains(tGraphemeWidth) {
+		s.wideDrift = true
 	}
+}
+
+// reanchor emits an absolute horizontal move when the terminal's cursor
+// column may disagree with ours. This happens after drawing wide glyphs on
+// terminals that did not negotiate Unicode grapheme width (mode 2027) and may
+// measure glyph widths differently (e.g. Terminal.app). Re-anchoring lazily
+// keeps the noise down: a run of wide glyphs re-anchors only once, right
+// before whatever needs an exact column next.
+func (s *TerminalRenderer) reanchor() {
+	if !s.wideDrift {
+		return
+	}
+	s.wideDrift = false
+	if s.atPhantom || s.cur.X < 0 {
+		return
+	}
+	_, _ = s.buf.WriteString(ansi.CursorHorizontalAbsolute(s.cur.X + 1))
 }
 
 // putCellLR draws a cell at the lower right corner of the screen.
@@ -646,6 +676,7 @@ func (s *TerminalRenderer) emitRange(newbuf *RenderBuffer, line Line, n int) (eo
 			cup := ansi.CursorPosition(s.cur.X+count, s.cur.Y)
 			rep := ansi.RepeatPreviousCharacter(count)
 			if hasECH && count > len(ech)+len(cup) && canClearWith(&cell0) {
+				s.reanchor() // ECH erases at the cursor position
 				s.updatePen(&cell0)
 				_, _ = s.buf.WriteString(ech)
 
@@ -758,6 +789,7 @@ func (s *TerminalRenderer) clearToEnd(newbuf *RenderBuffer, blank *Cell, force b
 	}
 
 	if force {
+		s.reanchor() // EL erases from the cursor position
 		s.updatePen(blank)
 		count := newbuf.Width() - s.cur.X
 		if s.el0Cost() <= count {
@@ -816,8 +848,8 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	oldLine := s.curbuf.Line(y)
 	newLine := newbuf.Line(y)
 
-	s.lineHadWide = false
-	defer s.reanchorWideLine(newbuf)
+	// Bound any residual drift from a trailing wide glyph to this line.
+	defer s.reanchor()
 
 	// Find the first changed cell in the line
 	blank := newLine.At(0)
@@ -1009,22 +1041,6 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	}
 }
 
-// reanchorWideLine re-anchors the cursor with a single absolute horizontal
-// move after a line that contained a wide cell. This is a best-effort fallback
-// that bounds cursor desync to one line on terminals whose width model
-// disagrees with ours. When the terminal negotiated Unicode grapheme width
-// (mode 2027) the models agree, so no re-anchor is needed.
-func (s *TerminalRenderer) reanchorWideLine(newbuf *RenderBuffer) {
-	if !s.lineHadWide || s.flags.Contains(tGraphemeWidth) {
-		return
-	}
-	s.lineHadWide = false
-	if s.atPhantom || s.cur.X < 0 || s.cur.X >= newbuf.Width() {
-		return
-	}
-	_, _ = s.buf.WriteString(ansi.CursorHorizontalAbsolute(s.cur.X + 1))
-}
-
 // deleteCells deletes the count cells at the current cursor position and moves
 // the rest of the line to the left. This is equivalent to [ansi.DCH].
 func (s *TerminalRenderer) deleteCells(count int) {
@@ -1107,6 +1123,7 @@ func (s *TerminalRenderer) clearScreen(blank *Cell) {
 	_, _ = s.buf.WriteString(ansi.CursorHomePosition)
 	_, _ = s.buf.WriteString(ansi.EraseEntireScreen)
 	s.cur.X, s.cur.Y = 0, 0
+	s.wideDrift = false
 	s.curbuf.Fill(blank)
 }
 
@@ -1448,6 +1465,12 @@ func relativeCursorMove(s *TerminalRenderer, newbuf *RenderBuffer, fx, fy, tx, t
 					cell := newbuf.CellAt(fx+i, ty)
 					if cell != nil && cell.Width > 0 {
 						i += cell.Width - 1
+						if cell.Width > 1 && !s.flags.Contains(tGraphemeWidth) {
+							// Overwriting wide glyphs drifts the cursor on
+							// terminals without mode 2027.
+							overwrite = false
+							break
+						}
 						if !cell.Style.Equal(&s.cur.Style) || !cell.Link.Equal(&s.cur.Link) {
 							overwrite = false
 							break

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -859,6 +859,12 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	// Bound any residual drift from a trailing wide glyph to this line.
 	defer s.reanchor()
 
+	if !s.flags.Contains(tGraphemeWidth) &&
+		(lineMayDrift(oldLine, newbuf.Width()) || lineMayDrift(newLine, newbuf.Width())) {
+		s.redrawDriftLine(newbuf, oldLine, newLine, y)
+		return
+	}
+
 	// Find the first changed cell in the line
 	blank := newLine.At(0)
 
@@ -1047,6 +1053,48 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	} else {
 		copy(oldLine, newLine)
 	}
+}
+
+// lineMayDrift reports whether the line contains cells that may desync the
+// terminal's cursor column on terminals without mode 2027.
+func lineMayDrift(line Line, width int) bool {
+	for x := 0; x < width; x++ {
+		if c := line.At(x); c != nil && cellMayDrift(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// redrawDriftLine erases and redraws a changed line wholly. Around
+// drift-prone glyphs, cell-level diffing cannot be trusted: the terminal may
+// have drawn them wider or narrower than we modeled, so the real screen
+// content around them differs from curbuf. Erasing first also wipes any
+// residue such glyphs left behind.
+func (s *TerminalRenderer) redrawDriftLine(newbuf *RenderBuffer, oldLine, newLine Line, y int) {
+	width := newbuf.Width()
+
+	firstCell := 0
+	for firstCell < width && cellEqual(oldLine.At(firstCell), newLine.At(firstCell)) {
+		firstCell++
+	}
+	if firstCell >= width {
+		return // nothing changed
+	}
+
+	s.move(newbuf, 0, y)
+
+	last := width - 1
+	if blank := newLine.At(last); canClearWith(blank) {
+		s.updatePen(blank)
+		_, _ = s.buf.WriteString(ansi.EraseLineRight)
+		for last > 0 && cellEqual(newLine.At(last), blank) {
+			last--
+		}
+	}
+	s.emitRange(newbuf, newLine, last+1)
+
+	copy(oldLine, newLine)
 }
 
 // deleteCells deletes the count cells at the current cursor position and moves

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -144,7 +144,7 @@ type TerminalRenderer struct {
 	clear            bool         // whether to force clear the screen
 	caps             capabilities // terminal control sequence capabilities
 	atPhantom        bool         // whether the cursor is out of bounds and at a phantom cell
-	lineHadWide      bool         // whether the line currently being transformed contained a wide cell
+	lineHadDrift     bool         // whether the line currently being transformed held a drift-prone cell
 	logger           Logger       // The logger used for debugging.
 
 	// profile is the color profile to use when downsampling colors. This is
@@ -543,8 +543,8 @@ func (s *TerminalRenderer) putAttrCell(newbuf *RenderBuffer, cell *Cell) {
 		s.atPhantom = true
 	}
 
-	if cellWidth > 1 {
-		s.lineHadWide = true
+	if cellHasDrift(s.method, cell) {
+		s.lineHadDrift = true
 	}
 }
 
@@ -808,6 +808,24 @@ func (s *TerminalRenderer) el0Cost() int {
 	return len(ansi.EraseLineRight)
 }
 
+// cellHasDrift reports whether the terminal may advance the cursor by a
+// different number of columns than the model measured for the cell: a wide
+// cell (width > 1) spans several columns, and a cell whose width the terminal
+// measures differently than the model (an emoji cluster, a keycap) leaves the
+// cursor at a column the model cannot predict.
+func cellHasDrift(m ansi.Method, c *Cell) bool {
+	if c == nil || c.Width == 0 || len(c.Content) == 0 {
+		return false
+	}
+	if c.Width > 1 {
+		return true
+	}
+	if len(c.Content) == 1 {
+		return false // ASCII, both models agree
+	}
+	return m.StringWidth(c.Content) != ansi.StringWidth(c.Content)
+}
+
 // lineHasDrift reports whether the line contains a cell that a cell-level
 // diff cannot safely reposition across: a wide cell (width > 1), or a cell
 // whose width the terminal may measure differently than the model. Wide cells
@@ -816,15 +834,24 @@ func (s *TerminalRenderer) el0Cost() int {
 // column each glyph landed on.
 func lineHasDrift(m ansi.Method, line Line) bool {
 	for i := 0; i < len(line); i++ {
-		c := line.At(i)
-		if c == nil || c.Width == 0 || len(c.Content) == 0 {
-			continue
-		}
-		if c.Width > 1 || m.StringWidth(c.Content) != ansi.StringWidth(c.Content) {
+		if cellHasDrift(m, line.At(i)) {
 			return true
 		}
 	}
 	return false
+}
+
+// lineEqual reports whether both lines hold the same cells.
+func lineEqual(a, b Line) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !cellEqual(a.At(i), b.At(i)) {
+			return false
+		}
+	}
+	return true
 }
 
 // repaintLine repaints a line from scratch. Unlike
@@ -839,6 +866,11 @@ func lineHasDrift(m ansi.Method, line Line) bool {
 func (s *TerminalRenderer) repaintLine(newbuf *RenderBuffer, y int) {
 	oldLine := s.curbuf.Line(y)
 	newLine := newbuf.Line(y)
+
+	if lineEqual(oldLine, newLine) {
+		// Nothing changed, no need to pay for a full repaint.
+		return
+	}
 
 	s.move(newbuf, 0, y)
 	blank := s.clearBlank()
@@ -874,8 +906,8 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	oldLine := s.curbuf.Line(y)
 	newLine := newbuf.Line(y)
 
-	s.lineHadWide = false
-	defer s.reanchorWideLine(newbuf)
+	s.lineHadDrift = false
+	defer s.reanchorDriftLine(newbuf)
 
 	// If either frame's line holds a cell that a cell-level diff cannot
 	// safely reposition across, repaint the whole line instead. A wide cell
@@ -1083,16 +1115,16 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 	}
 }
 
-// reanchorWideLine re-anchors the cursor with a single absolute horizontal
-// move after a line that contained a wide cell. This is a best-effort fallback
-// that bounds cursor desync to one line on terminals whose width model
-// disagrees with ours. When the terminal negotiated Unicode grapheme width
-// (mode 2027) the models agree, so no re-anchor is needed.
-func (s *TerminalRenderer) reanchorWideLine(newbuf *RenderBuffer) {
-	if !s.lineHadWide || s.flags.Contains(tGraphemeWidth) {
+// reanchorDriftLine re-anchors the cursor with a single absolute horizontal
+// move after a line that held a drift-prone cell. This is a best-effort
+// fallback that bounds cursor desync to one line on terminals whose width
+// model disagrees with ours. When the terminal negotiated Unicode grapheme
+// width (mode 2027) the models agree, so no re-anchor is needed.
+func (s *TerminalRenderer) reanchorDriftLine(newbuf *RenderBuffer) {
+	if !s.lineHadDrift || s.flags.Contains(tGraphemeWidth) {
 		return
 	}
-	s.lineHadWide = false
+	s.lineHadDrift = false
 	if s.atPhantom || s.cur.X < 0 || s.cur.X >= newbuf.Width() {
 		return
 	}

--- a/terminal_renderer_output_test.go
+++ b/terminal_renderer_output_test.go
@@ -215,6 +215,34 @@ func TestRendererNarrowAfterWideReanchor(t *testing.T) {
 	}
 }
 
+func TestRendererNarrowClusterReanchor(t *testing.T) {
+	// Under wcwidth, a VS16+ZWJ cluster like "⛓️‍💥" is a single-rune-wide
+	// (width 1) cell holding several runes. Terminals without mode 2027 may
+	// advance the cursor further than one column for it, so the next cell
+	// still needs a re-anchor.
+	var buf bytes.Buffer
+	s := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+	s.SetFullscreen(true)
+	s.SetGraphemeWidth(false)
+	s.SaveCursor()
+	s.Erase()
+
+	scr := NewScreenBuffer(10, 1)
+	NewStyledString("⛓️‍💥|ab").Draw(scr, scr.Bounds())
+	s.Render(scr.RenderBuffer)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "\x1b[2G|") {
+		t.Errorf("cell after a multi-rune narrow cluster should be re-anchored: %q", out)
+	}
+}
+
 var loremIpsum = []string{
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare risus, quis lacinia magna. Suspendisse egestas purus risus, id rutrum diam porta non. Duis luctus tempus dictum. Maecenas luctus metus vitae nulla consectetur egestas. Curabitur faucibus nunc vel eros semper scelerisque. Proin dictum aliquam lacus dignissim fringilla. Praesent ut quam id dui aliquam vehicula in vitae orci. Fusce imperdiet aliquam quam. Nullam euismod magna tincidunt nisl ullamcorper, dignissim rutrum arcu rutrum. Nulla ac fringilla velit. Duis non pellentesque erat.",
 	"In egestas ex et sem vulputate, congue bibendum diam ultrices. Nam auctor dictum enim, in rutrum nulla vestibulum sit amet. Vestibulum vel velit ac sem pellentesque accumsan. Vivamus pharetra mi non arcu tristique gravida. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed molestie lectus nunc, sit amet rhoncus orci laoreet vel. Nulla eget mattis massa. Nunc porta eros sollicitudin lorem dapibus luctus. Vestibulum ut turpis ut nibh tincidunt feugiat. Integer eget augue nunc. Morbi vitae ultrices neque. Nulla et convallis libero. Cras nec faucibus odio. Maecenas lacinia sed odio sit amet ultrices.",

--- a/terminal_renderer_output_test.go
+++ b/terminal_renderer_output_test.go
@@ -243,6 +243,45 @@ func TestRendererNarrowClusterReanchor(t *testing.T) {
 	}
 }
 
+func TestRendererDriftLineRedraw(t *testing.T) {
+	// Around drift-prone glyphs the terminal's actual screen content may not
+	// match the renderer's model, so an incremental update of such a line
+	// must erase and redraw it wholly instead of diffing cells.
+	var buf bytes.Buffer
+	s := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+	s.SetFullscreen(true)
+	s.SetGraphemeWidth(false)
+	s.SaveCursor()
+	s.Erase()
+
+	scr := NewScreenBuffer(10, 1)
+	NewStyledString("a世b|x").Draw(scr, scr.Bounds())
+	s.Render(scr.RenderBuffer)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	buf.Reset()
+	NewStyledString("a界b|x").Draw(scr, scr.Bounds())
+	s.Render(scr.RenderBuffer)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "\x1b[K") {
+		t.Errorf("drift-prone line should be erased before redraw: %q", out)
+	}
+	// The unchanged leading "a" must be rewritten too; a re-anchor may be
+	// interleaved after the wide glyph.
+	if !strings.Contains(out, "a界") || !strings.Contains(out, "b|x") {
+		t.Errorf("drift-prone line should be redrawn wholly: %q", out)
+	}
+}
+
 var loremIpsum = []string{
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare risus, quis lacinia magna. Suspendisse egestas purus risus, id rutrum diam porta non. Duis luctus tempus dictum. Maecenas luctus metus vitae nulla consectetur egestas. Curabitur faucibus nunc vel eros semper scelerisque. Proin dictum aliquam lacus dignissim fringilla. Praesent ut quam id dui aliquam vehicula in vitae orci. Fusce imperdiet aliquam quam. Nullam euismod magna tincidunt nisl ullamcorper, dignissim rutrum arcu rutrum. Nulla ac fringilla velit. Duis non pellentesque erat.",
 	"In egestas ex et sem vulputate, congue bibendum diam ultrices. Nam auctor dictum enim, in rutrum nulla vestibulum sit amet. Vestibulum vel velit ac sem pellentesque accumsan. Vivamus pharetra mi non arcu tristique gravida. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed molestie lectus nunc, sit amet rhoncus orci laoreet vel. Nulla eget mattis massa. Nunc porta eros sollicitudin lorem dapibus luctus. Vestibulum ut turpis ut nibh tincidunt feugiat. Integer eget augue nunc. Morbi vitae ultrices neque. Nulla et convallis libero. Cras nec faucibus odio. Maecenas lacinia sed odio sit amet ultrices.",

--- a/terminal_renderer_output_test.go
+++ b/terminal_renderer_output_test.go
@@ -184,6 +184,37 @@ func TestRendererWideCellReanchor(t *testing.T) {
 	}
 }
 
+func TestRendererNarrowAfterWideReanchor(t *testing.T) {
+	// Mirrors the sidebar example: a narrow cell (separator) drawn after wide
+	// glyphs must be preceded by an absolute column move on terminals without
+	// mode 2027, otherwise its column is at the mercy of the terminal's own
+	// width tables (e.g. Terminal.app).
+	var buf bytes.Buffer
+	s := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+	s.SetFullscreen(true)
+	s.SetGraphemeWidth(false)
+	s.SaveCursor()
+	s.Erase()
+
+	scr := NewScreenBuffer(10, 1)
+	NewStyledString("世界|ab").Draw(scr, scr.Bounds())
+	s.Render(scr.RenderBuffer)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "\x1b[5G|") {
+		t.Errorf("separator after wide glyphs should be re-anchored to its column: %q", out)
+	}
+	if n := strings.Count(out, "G"); n != 1 {
+		t.Errorf("want a single re-anchor for the whole narrow run, got %d in %q", n, out)
+	}
+}
+
 var loremIpsum = []string{
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare risus, quis lacinia magna. Suspendisse egestas purus risus, id rutrum diam porta non. Duis luctus tempus dictum. Maecenas luctus metus vitae nulla consectetur egestas. Curabitur faucibus nunc vel eros semper scelerisque. Proin dictum aliquam lacus dignissim fringilla. Praesent ut quam id dui aliquam vehicula in vitae orci. Fusce imperdiet aliquam quam. Nullam euismod magna tincidunt nisl ullamcorper, dignissim rutrum arcu rutrum. Nulla ac fringilla velit. Duis non pellentesque erat.",
 	"In egestas ex et sem vulputate, congue bibendum diam ultrices. Nam auctor dictum enim, in rutrum nulla vestibulum sit amet. Vestibulum vel velit ac sem pellentesque accumsan. Vivamus pharetra mi non arcu tristique gravida. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed molestie lectus nunc, sit amet rhoncus orci laoreet vel. Nulla eget mattis massa. Nunc porta eros sollicitudin lorem dapibus luctus. Vestibulum ut turpis ut nibh tincidunt feugiat. Integer eget augue nunc. Morbi vitae ultrices neque. Nulla et convallis libero. Cras nec faucibus odio. Maecenas lacinia sed odio sit amet ultrices.",

--- a/terminal_renderer_output_test.go
+++ b/terminal_renderer_output_test.go
@@ -184,6 +184,76 @@ func TestRendererWideCellReanchor(t *testing.T) {
 	}
 }
 
+func TestRendererNarrowClusterReanchor(t *testing.T) {
+	// Under wcwidth a VS16 cluster such as "☹️" measures a single column, but a
+	// terminal that doesn't negotiate mode 2027 may advance the cursor further.
+	// Such a line must be re-anchored too, otherwise the drift leaks into the
+	// relative cursor movements of the following lines.
+	render := func(grapheme bool) string {
+		var buf bytes.Buffer
+		s := NewTerminalRenderer(&buf, []string{
+			"TERM=xterm-256color",
+			"COLORTERM=truecolor",
+		})
+		s.SetFullscreen(true)
+		s.SetGraphemeWidth(grapheme)
+		s.SaveCursor()
+		s.Erase()
+
+		scr := NewScreenBuffer(10, 2)
+		buf.Reset()
+		NewStyledString("☹️abc\n     Z").Draw(scr, scr.Bounds())
+		s.Render(scr.RenderBuffer)
+		if err := s.Flush(); err != nil {
+			t.Fatalf("Flush failed: %v", err)
+		}
+		return buf.String()
+	}
+
+	if out := render(false); !strings.Contains(out, "\x1b[5G") {
+		t.Errorf("line with a narrow cluster should be re-anchored: %q", out)
+	}
+	if out := render(true); strings.Contains(out, "\x1b[5G") {
+		t.Errorf("grapheme-mode line should not re-anchor: %q", out)
+	}
+}
+
+func TestRendererUnchangedDriftLineNotRepainted(t *testing.T) {
+	// Lines that hold drift-prone cells are repainted instead of diffed, but
+	// only when they actually changed: an untouched line must cost nothing.
+	var buf bytes.Buffer
+	s := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+	s.SetFullscreen(true)
+	s.SetGraphemeWidth(false)
+	s.SaveCursor()
+	s.Erase()
+
+	scr := NewScreenBuffer(10, 2)
+	NewStyledString("☹️世abc\nxyz").Draw(scr, scr.Bounds())
+	s.Render(scr.RenderBuffer)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	buf.Reset()
+	NewStyledString("☹️世abc\nxyZ").Draw(scr, scr.Bounds())
+	s.Render(scr.RenderBuffer)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "☹️") || strings.Contains(out, "世") {
+		t.Errorf("unchanged drift-prone line was repainted: %q", out)
+	}
+	if !strings.Contains(out, "Z") {
+		t.Errorf("changed line was not updated: %q", out)
+	}
+}
+
 var loremIpsum = []string{
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare risus, quis lacinia magna. Suspendisse egestas purus risus, id rutrum diam porta non. Duis luctus tempus dictum. Maecenas luctus metus vitae nulla consectetur egestas. Curabitur faucibus nunc vel eros semper scelerisque. Proin dictum aliquam lacus dignissim fringilla. Praesent ut quam id dui aliquam vehicula in vitae orci. Fusce imperdiet aliquam quam. Nullam euismod magna tincidunt nisl ullamcorper, dignissim rutrum arcu rutrum. Nulla ac fringilla velit. Duis non pellentesque erat.",
 	"In egestas ex et sem vulputate, congue bibendum diam ultrices. Nam auctor dictum enim, in rutrum nulla vestibulum sit amet. Vestibulum vel velit ac sem pellentesque accumsan. Vivamus pharetra mi non arcu tristique gravida. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed molestie lectus nunc, sit amet rhoncus orci laoreet vel. Nulla eget mattis massa. Nunc porta eros sollicitudin lorem dapibus luctus. Vestibulum ut turpis ut nibh tincidunt feugiat. Integer eget augue nunc. Morbi vitae ultrices neque. Nulla et convallis libero. Cras nec faucibus odio. Maecenas lacinia sed odio sit amet ultrices.",


### PR DESCRIPTION
On terminals that don't negotiate Unicode grapheme width (DEC mode 2027), such
as Apple Terminal.app, emoji and other clusters advance the cursor by a
different number of columns than the renderer models.

Since this PR was opened, `main` grew `lineHasDrift`/`repaintLine`, which
repaints such lines from column 0 instead of diffing them — the approach
suggested in review. This PR is now rebased and reduced to the two gaps that
remain around it:

- **Skip repainting unchanged drift-prone lines.** `repaintLine` fired on every
  frame, even when the line was identical to the previous one. On a 100x30
  screen of emoji: an identical frame goes from 8611 bytes to 0, and a frame
  with a single changed line from 8611 to 291.
- **Re-anchor lines whose only drift source is a narrow cluster.** The
  end-of-line re-anchor only armed for cells with `Width > 1`, so a line holding
  a VS16/ZWJ cluster (one column under wcwidth) left the cursor at an
  unpredictable column, and the next lines moved relatively from it
  (e.g. `\n Z`) and landed off by the drift. The drift predicate used by
  `repaintLine` is now shared with the re-anchor.

No mid-line re-anchoring: as pointed out in review, an absolute column move
computed from the model can land inside a glyph the terminal painted wider and
the following write would then erase it.

Also adds the `sidebar` example (chat-style layout with a vertical separator and
emoji) used to reproduce this.

Tested on Terminal, iTerm and Ghostty.
