### PR TITLE
test: fix TestReader flake

### DIFF
--- a/poll_default_test.go
+++ b/poll_default_test.go
@@ -22,16 +22,10 @@ func TestReader(t *testing.T) {
 		t.Errorf("expected no error, but got %s", err)
 	}
 
-	msg := "hello"
-	n, err := pw.Write([]byte(msg))
-	if n != 5 {
-		t.Errorf("expected 5 bytes written but got %d", n)
-	}
-	if err != nil {
-		t.Errorf("expected no error, but got %s", err)
-	}
-
+	// Don't write anything to the pipe yet so the read below blocks and
+	// cannot complete before the cancellation.
 	done := make(chan struct{})
+	var n int
 	go func() {
 		defer close(done)
 		p := make([]byte, 1)
@@ -56,6 +50,14 @@ func TestReader(t *testing.T) {
 
 	// Test that read is still possible after cancellation.
 	pollReader, err = newPollReader(pr)
+	if err != nil {
+		t.Errorf("expected no error, but got %s", err)
+	}
+	msg := "hello"
+	n, err = pw.Write([]byte(msg))
+	if n != 5 {
+		t.Errorf("expected 5 bytes written but got %d", n)
+	}
 	if err != nil {
 		t.Errorf("expected no error, but got %s", err)
 	}


### PR DESCRIPTION
TestReader is flaky: it writes to the pipe before starting the read that is expected to be cancelled. If the read wins the race against `Cancel()`, it consumes a byte and returns successfully, failing the test (as seen on the coverage job of #131):

```
poll_default_test.go:51: expected 0 bytes read but got 1
poll_default_test.go:54: expected cancel error but got <nil>
poll_default_test.go:65: expected 5 bytes written but got 4
poll_default_test.go:71: expected to read "hell" but got "ello"
```

Fix: keep the pipe empty during the cancellation phase so the read reliably blocks, and write the data only for the post-cancellation read.

Verified with `go test --count=50 -run TestReader` and `go test -race --count=20 -run TestReader`.