### PR TITLE
fix(renderer): emit CRLF for downward cursor moves in inline mode

### DIFF
--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -1378,9 +1378,23 @@ func relativeCursorMove(s *TerminalRenderer, newbuf *RenderBuffer, fx, fy, tx, t
 				yseq = cud
 			}
 			if !s.flags.Contains(tFullscreen) || n < len(yseq) { // n is the cost of using newline characters
-				yseq = strings.Repeat("\n", n)
-				if s.flags.Contains(tMapNewline) {
+				if s.flags.Contains(tRelativeCursor) {
+					// When tracking the cursor position relatively (i.e. not
+					// fullscreen), any horizontal move computed below relies
+					// on our own bookkeeping of the cursor's column. We can't
+					// depend on the terminal mapping LF to CRLF for us here:
+					// programs using this renderer run the terminal in raw
+					// mode, which disables that OS-level translation. Emit an
+					// explicit carriage return with every line feed so the
+					// column really does reset to 0, matching the
+					// full-redraw code paths (e.g. [StyledString.Draw]).
+					yseq = strings.Repeat("\r\n", n)
 					fx = 0
+				} else {
+					yseq = strings.Repeat("\n", n)
+					if s.flags.Contains(tMapNewline) {
+						fx = 0
+					}
 				}
 			}
 		} else if ty < fy {

--- a/terminal_renderer_crlf_test.go
+++ b/terminal_renderer_crlf_test.go
@@ -1,0 +1,72 @@
+package uv
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestRendererInlinePartialUpdateEmitsCRLF is a regression test for
+// https://github.com/charmbracelet/ultraviolet/issues/61.
+//
+// In inline (non-fullscreen) mode, when a single frame touches two
+// non-adjacent rows (e.g. redrawing a box near the top of the screen and
+// another box further down, leaving the rows between them untouched), the
+// renderer moves the cursor down to the next touched row using bare line
+// feeds ("\n") as a cost optimization in [relativeCursorMove]. Programs
+// using this renderer run the terminal in raw mode, which disables the
+// OS-level LF->CRLF translation a cooked terminal performs, so every line
+// feed used to move the cursor down must be paired with a carriage return.
+// Otherwise the terminal's actual cursor column drifts from what the
+// renderer assumes it is, corrupting the following in-place update.
+func TestRendererInlinePartialUpdateEmitsCRLF(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewTerminalRenderer(&buf, []string{
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	})
+
+	// Match the defaults [TerminalScreen] uses for inline rendering: not
+	// fullscreen, relative cursor tracking, and no newline auto-mapping
+	// (raw mode, see terminal_screen.go).
+	s.SetFullscreen(false)
+	s.SetRelativeCursor(true)
+	s.SetMapNewline(false)
+
+	const width, height = 10, 6
+	scr := NewScreenBuffer(width, height)
+
+	// Draw an initial full frame occupying every row, similar to the
+	// 3-layer canvas in the issue rendering a full screen of boxes.
+	for y := range height {
+		for x := range width {
+			scr.SetCell(x, y, NewCell(scr.WidthMethod(), "x"))
+		}
+	}
+	s.Render(scr.RenderBuffer)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("initial Flush failed: %v", err)
+	}
+
+	// Mutate two non-adjacent rows in a single frame: row 0 (the "top box")
+	// and row 3 (the "bottom-left box"), leaving rows 1-2 untouched. This
+	// forces the renderer to jump the cursor down multiple rows in one
+	// move, exercising the newline fast path in [relativeCursorMove].
+	buf.Reset()
+	scr.SetCell(5, 0, NewCell(scr.WidthMethod(), "A"))
+	scr.SetCell(0, 3, NewCell(scr.WidthMethod(), "B"))
+
+	s.Render(scr.RenderBuffer)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("partial update Flush failed: %v", err)
+	}
+
+	out := buf.Bytes()
+	if !bytes.Contains(out, []byte("\n")) {
+		t.Fatalf("expected the partial update to move the cursor across rows, got no line feed in %q", out)
+	}
+	for i, b := range out {
+		if b == '\n' && (i == 0 || out[i-1] != '\r') {
+			t.Fatalf("bare LF without a preceding CR at output byte %d: %q", i, out)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #61

relativeCursorMove's newline fast path always wrote bare "\n" to move the cursor down, and only reset the tracked column (fx) when tMapNewline was set. TerminalScreen always calls SetMapNewline(false), so in the common inline (non-fullscreen, relative-cursor) case the renderer emitted a bare LF but still assumed the column reset, even though the terminal runs in raw mode with no LF->CRLF translation. That desyncs the renderer's column bookkeeping from the terminal's real cursor, corrupting whatever gets drawn on the next in-place update (the two-boxes case from the issue).

This pairs the LF with a CR (and resets fx) in the relative-cursor branch, since that's the path TerminalScreen actually exercises today.

I noticed the "do we still need map nl to crlf handling" comment on the SetMapNewline(false) call in terminal_screen.go, so tMapNewline's contract might be worth revisiting instead of adding another branch here. I kept this scoped to the reported symptom and the relative-cursor path since that's what's actually broken today, but happy to rework it if you'd rather key this off tMapNewline directly (or drop it) so the CR/LF decision isn't split across two flags.

Added a regression test (terminal_renderer_crlf_test.go) reproducing the two-non-adjacent-rows scenario from the issue: asserts every LF in the output is preceded by a CR.
