### PR TITLE
buffer: clamp stale line areas to buffer bounds

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -459,6 +459,10 @@ func (b *Buffer) InsertLine(y, n int, c *Cell) {
 // rectangle's horizontal bounds are affected. Lines are pushed out of the
 // rectangle bounds and lost. This follows terminal [ansi.IL] behavior.
 func (b *Buffer) InsertLineArea(y, n int, c *Cell, area Rectangle) {
+	// Normalize the area to the buffer bounds. Callers may hold a stale
+	// area (e.g. a terminal scroll region computed before a resize), and
+	// operating on it as-is would index past the end of b.Lines.
+	area = area.Intersect(b.Bounds())
 	if n <= 0 || y < area.Min.Y || y >= area.Max.Y || y >= b.Height() {
 		return
 	}
@@ -490,6 +494,8 @@ func (b *Buffer) InsertLineArea(y, n int, c *Cell, area Rectangle) {
 // new blank lines are created at the bottom. This follows terminal [ansi.DL]
 // behavior.
 func (b *Buffer) DeleteLineArea(y, n int, c *Cell, area Rectangle) {
+	// Normalize the area to the buffer bounds; see InsertLineArea.
+	area = area.Intersect(b.Bounds())
 	if n <= 0 || y < area.Min.Y || y >= area.Max.Y || y >= b.Height() {
 		return
 	}

--- a/buffer_area_bounds_test.go
+++ b/buffer_area_bounds_test.go
@@ -1,0 +1,42 @@
+package uv
+
+import "testing"
+
+// These tests cover the area-bounds invariant of InsertLineArea and
+// DeleteLineArea: an area extending past the buffer bounds (e.g. a terminal
+// scroll region computed before a resize) must be clamped instead of
+// indexing past the end of b.Lines.
+
+func TestInsertLineAreaClampsOversizedArea(t *testing.T) {
+	b := NewBuffer(80, 63)
+	area := Rect(0, 0, 80, 64) // Max.Y exceeds Height by one
+
+	// Used to panic: index out of range [63] with length 63.
+	b.InsertLineArea(0, 1, nil, area)
+}
+
+func TestDeleteLineAreaClampsOversizedArea(t *testing.T) {
+	b := NewBuffer(80, 63)
+	area := Rect(0, 0, 80, 64)
+
+	b.DeleteLineArea(0, 1, nil, area)
+}
+
+func TestInsertLineAreaClampsOversizedWidth(t *testing.T) {
+	b := NewBuffer(80, 24)
+	area := Rect(0, 0, 100, 24) // Max.X exceeds Width
+
+	b.InsertLineArea(0, 1, nil, area)
+}
+
+func TestInsertLineAreaStillShiftsLinesWithinBounds(t *testing.T) {
+	b := NewBuffer(4, 3)
+	c := &Cell{Content: "a", Width: 1}
+	b.SetCell(0, 0, c)
+
+	b.InsertLineArea(0, 1, nil, b.Bounds())
+
+	if got := b.CellAt(0, 1); got == nil || got.Content != "a" {
+		t.Errorf("line 0 was not shifted down to line 1, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
Clamp `InsertLineArea` and `DeleteLineArea` to `b.Bounds()` before operating on the area.

## Why
Callers can hold a stale scroll region across a resize. If `area.Max.Y` or `area.Max.X` extends past the current buffer bounds, the existing loops can index past the end of `b.Lines` and panic.

## Changes
- intersect `area` with `b.Bounds()` at the start of `InsertLineArea`
- do the same in `DeleteLineArea`
- add regression tests for oversized height, oversized width, and in-bounds shifting behavior

## Test
- `go test ./...`
