### PR TITLE
fix(cancelreader): cancel reads on any console handle, not just os.Stdin

### DIFF
--- a/cancelreader_windows.go
+++ b/cancelreader_windows.go
@@ -6,7 +6,6 @@ package uv
 import (
 	"fmt"
 	"io"
-	"os"
 	"sync"
 
 	xwindows "github.com/charmbracelet/x/windows"
@@ -30,17 +29,21 @@ func NewCancelReader(r io.Reader) (cancelreader.CancelReader, error) {
 		return cancelreader.NewReader(r)
 	}
 
-	var dummy uint32
-	if f, ok := r.(cancelreader.File); !ok || f.Fd() != os.Stdin.Fd() ||
-		// If data was piped to the standard input, it does not emit events
-		// anymore. We can detect this if the console mode cannot be set anymore,
-		// in this case, we fallback to the default cancelreader implementation.
-		windows.GetConsoleMode(windows.Handle(f.Fd()), &dummy) != nil {
+	f, ok := r.(cancelreader.File)
+	if !ok {
 		return fallback(r)
 	}
 
-	conin, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
-	if err != nil {
+	// Read from the handle we were handed rather than assuming standard input. A
+	// caller whose stdio is redirected opens CONIN$ itself and passes it here: that
+	// handle is a console, even though it is not os.Stdin.
+	conin := windows.Handle(f.Fd())
+
+	// If data was piped in, the handle does not emit console events. GetConsoleMode
+	// fails on a handle that is not a console, so fall back to the default
+	// cancelreader implementation in that case.
+	var dummy uint32
+	if windows.GetConsoleMode(conin, &dummy) != nil {
 		return fallback(r)
 	}
 

--- a/cancelreader_windows_test.go
+++ b/cancelreader_windows_test.go
@@ -1,0 +1,73 @@
+//go:build windows
+// +build windows
+
+package uv
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// openConsoleInput opens CONIN$ the same way a caller does when stdio is
+// redirected and it still wants to talk to the console. The handle is a console
+// handle, but it is not os.Stdin.
+func openConsoleInput(t *testing.T) *os.File {
+	t.Helper()
+
+	f, err := os.OpenFile("CONIN$", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("no console attached to this process: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	return f
+}
+
+// A CONIN$ handle is a console handle, so it must get the console reader, not the
+// fallback reader. The fallback cannot cancel an in-flight read.
+func TestNewCancelReaderConsoleHandleIsNotFallback(t *testing.T) {
+	r, err := NewCancelReader(openConsoleInput(t))
+	if err != nil {
+		t.Fatalf("NewCancelReader: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	if _, ok := r.(*conInputReader); !ok {
+		t.Errorf("got %T for a console handle, want *conInputReader", r)
+	}
+}
+
+// Cancel must interrupt a read that is already blocked on the console.
+//
+// The console input buffer is empty and nobody is typing, so the read below never
+// completes on its own. If Cancel cannot interrupt it, the read blocks forever:
+// callers that rely on Cancel to enforce a timeout (lipgloss's terminal query does)
+// hang instead of timing out.
+func TestCancelUnblocksBlockedConsoleRead(t *testing.T) {
+	r, err := NewCancelReader(openConsoleInput(t))
+	if err != nil {
+		t.Fatalf("NewCancelReader: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	read := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 16)
+		_, err := r.Read(buf)
+		read <- err
+	}()
+
+	// Let the read block on the empty console input buffer.
+	time.Sleep(100 * time.Millisecond)
+
+	if !r.Cancel() {
+		t.Error("Cancel returned false: the blocked read was not interrupted")
+	}
+
+	select {
+	case <-read:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Read still blocked 5s after Cancel")
+	}
+}


### PR DESCRIPTION
---

Found while tracking down a start-up hang in [tea](https://gitea.com/gitea/tea), the Gitea CLI,
which blocks forever on Windows when its stdio is redirected: https://gitea.com/gitea/tea/issues/1053

## The problem

`NewCancelReader` only uses `conInputReader` when the reader is `os.Stdin`:

```go
if f, ok := r.(cancelreader.File); !ok || f.Fd() != os.Stdin.Fd() || ... {
    return fallback(r)
}
```

Any other handle goes to `cancelreader.NewReader`, which applies the same `os.Stdin` check and
falls back again to `fallbackCancelReader`. Its `Cancel()` is:

```go
func (r *fallbackCancelReader) Cancel() bool {
	r.setCanceled()
	return false
}
```

It flags the reader, but it cannot interrupt a read that is already blocked. A caller that relies
on `Cancel()` to enforce a timeout waits forever instead.

That is reachable from lipgloss today. When stdio is redirected, `lipgloss.BackgroundColor` opens
`CONIN$` and passes it here. `CONIN$` is a console handle, but it is not `os.Stdin`, so the
terminal query takes the fallback and its 2 second timeout never fires. Any Windows program with
redirected stdio — a service, a CI runner — hangs on start-up.

There is a second bug in the same function: it ignores `r` and reads from
`GetStdHandle(STD_INPUT_HANDLE)` regardless, so even in the accepted case it reads standard input
rather than the reader it was given.

## The fix

Key off whether the handle is a console rather than whether it is `os.Stdin`, and use the handle
we were actually handed. The `GetConsoleMode` probe already distinguishes a console from a pipe,
which is what the original `os.Stdin` check was reaching for.

`conInputReader.Cancel()` uses `CancelIoEx`, and that does interrupt a blocking `ReadFile` on a
console handle — I checked before writing this, with a small program that blocks a goroutine in
`ReadFile(CONIN$)` and cancels it from another. The read aborts immediately with
`ERROR_OPERATION_ABORTED`. So the console reader was always capable of this; it just wasn't being
selected.

## Tests

`cancelreader_windows_test.go`, two tests, both against an explicitly opened `CONIN$` (they skip
when no console is attached):

- a console handle must get `conInputReader`, not the fallback
- `Cancel()` must interrupt a read that is already blocked on the console

Against `main` they fail:

```
--- FAIL: TestNewCancelReaderConsoleHandleIsNotFallback
    got *cancelreader.fallbackCancelReader for a console handle, want *conInputReader
--- FAIL: TestCancelUnblocksBlockedConsoleRead
    Cancel returned false: the blocked read was not interrupted
    Read still blocked 5s after Cancel
```

With the fix they pass, and the blocked read returns in 0.10s. `go vet ./...` and `go test ./...`
are clean on Windows.