### PR TITLE
fix(renderer): don't split wide cell when deleting a preceding narrow cell

### DIFF
--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -987,6 +987,20 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 				s.insertCells(newbuf, newLine[n+1:], nLastCell-oLastCell)
 			}
 		} else if oLastCell > nLastCell {
+			// If the last reprinted cell (at n) is a wide character, its
+			// continuation (zero-width) cell occupies n+1. Deleting at n+1
+			// would split the wide character and corrupt the display (e.g.
+			// injecting a phantom space between CJK glyphs). Advance past the
+			// continuation cell(s) so that DCH targets the first real cell to
+			// remove. This mirrors the wide-char adjustment in the insert
+			// branch above.
+			if n >= firstCell && newLine.At(n) != nil && newLine.At(n).Width > 1 {
+				next := newLine.At(n + 1)
+				for next.isWidePlaceholder() {
+					n++
+					next = newLine.At(n + 1)
+				}
+			}
 			s.move(newbuf, n+1, y)
 			dchCost := 3 + oLastCell - nLastCell
 			if dchCost > len(ansi.EraseLineRight)+nLastNonBlank-(n+1) {

--- a/terminal_renderer_output_test.go
+++ b/terminal_renderer_output_test.go
@@ -2,6 +2,7 @@ package uv
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -181,6 +182,74 @@ func TestRendererWideCellReanchor(t *testing.T) {
 	gout := render(true)
 	if n := strings.Count(gout, "\x1b[5G"); n != 0 {
 		t.Errorf("grapheme-mode line should not re-anchor, got %d in %q", n, gout)
+	}
+}
+
+// TestRendererDeleteBeforeWideCell verifies that deleting a narrow cell that
+// precedes a wide cell does not split the wide cell.
+//
+// When the tail of a line is shorter than before, transformLine takes the DCH
+// (delete character) branch. The last reprinted cell may be a wide character
+// whose zero-width continuation occupies the next column. Without guarding for
+// that continuation, the renderer moves the cursor back onto it (ESC[D) and
+// issues DCH there, deleting the right half of the wide cell and corrupting the
+// glyph. In grapheme-width mode (mode 2027) there is no reanchor fallback, so
+// the corruption is permanent.
+//
+// The wide cell may sit anywhere on the line, so the cases interleave wide and
+// narrow cells: leading, medial (between two wide cells), and within multiple
+// wide runs, not just a trailing CJK run. Each case removes one narrow cell
+// that immediately precedes a wide cell, forcing the DCH branch to reprint the
+// wide cell as its last cell.
+func TestRendererDeleteBeforeWideCell(t *testing.T) {
+	cases := []struct {
+		name   string
+		before string
+		after  string
+	}{
+		{"trailing wide run", "engli世界", "engl世界"},
+		{"delete leading narrow before wide", "a世b界c", "世b界c"},
+		{"delete medial narrow between wides", "a世b界c", "a世界c"},
+		{"wide neighbors on both sides", "世a界b世", "世界b世"},
+		{"multiple wide runs, leading delete", "x世y界z国", "世y界z国"},
+		{"multiple wide runs, medial delete", "x世y界z国", "x世界z国"},
+	}
+
+	render := func(grapheme bool, before, after string) string {
+		var buf bytes.Buffer
+		s := NewTerminalRenderer(&buf, []string{
+			"TERM=xterm-256color",
+			"COLORTERM=truecolor",
+		})
+		s.SetFullscreen(true)
+		s.SetGraphemeWidth(grapheme)
+		s.SaveCursor()
+		s.Erase()
+
+		scr := NewScreenBuffer(12, 1)
+		for _, in := range []string{before, after} {
+			buf.Reset()
+			NewStyledString(in).Draw(scr, scr.Bounds())
+			s.Render(scr.RenderBuffer)
+			if err := s.Flush(); err != nil {
+				t.Fatalf("Flush failed: %v", err)
+			}
+		}
+		// Only the last frame (the delete) is asserted on.
+		return buf.String()
+	}
+
+	for _, grapheme := range []bool{false, true} {
+		for _, c := range cases {
+			t.Run(fmt.Sprintf("%s/grapheme=%v", c.name, grapheme), func(t *testing.T) {
+				out := render(grapheme, c.before, c.after)
+				// A cursor-back (ESC[D) immediately before DCH (ESC[P) means the
+				// delete landed on the wide continuation cell, splitting the glyph.
+				if strings.Contains(out, "\x1b[D\x1b[P") {
+					t.Errorf("DCH split the wide cell (spurious ESC[D before ESC[P): %q", out)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
### Summary

Fixes #139.

`transformLine`'s delete (DCH) branch did not skip wide-character continuation
cells, so deleting a narrow cell that precedes a wide cell moved the cursor
back onto the wide cell's zero-width continuation and issued DCH there,
splitting the glyph. The insert branch already has this guard; this mirrors it
in the delete branch.

### Before / after

Repro: render `"engli世界"`, then `"engl世界"` on a 12-cell screen. Emitted
bytes for the delete frame:

| mode | before (buggy) | after (fixed) |
|---|---|---|
| non-grapheme | `\x1b[5G世`**`\x1b[D`**`\x1b[P\x1b[6G` | `\x1b[5G世\x1b[P\x1b[7G` |
| grapheme (2027) | `\x1b[5G世`**`\x1b[D`**`\x1b[P` | `\x1b[5G世\x1b[P` |

The spurious `\x1b[D` before `\x1b[P` is the split. In grapheme-width mode
there is no `reanchorWideLine` fallback, so the corruption was permanent there.
The wide cell can sit anywhere on the line, so this reproduces not just with a
trailing CJK run but also when the deleted narrow cell is leading, medial
(between two wide cells), or inside multiple wide runs.

### Changes

- `terminal_renderer.go`: skip wide continuation cell(s) before DCH in the
  `oLastCell > nLastCell` branch, mirroring the insert branch.
- `terminal_renderer_output_test.go`: add `TestRendererDeleteBeforeWideCell`,
  table-driven over interleaved wide/narrow layouts (trailing, leading, medial
  between wides, wide neighbors on both sides, multiple wide runs) × both width
  modes. Every case fails without the fix and passes with it.

### Verification

- `go test ./...` passes; `go vet` and `gofmt` clean.
- New test fails on `main` for all interleaved cases (both modes) and passes
  with this change.

Assisted-by: Gemini