### PR TITLE
perf(buffer): rotate lines instead of copying cells when scrolling

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -454,6 +454,28 @@ func (b *Buffer) InsertLine(y, n int, c *Cell) {
 	b.InsertLineArea(y, n, c, b.Bounds())
 }
 
+// canRotateLines reports whether [Buffer.InsertLineArea] and
+// [Buffer.DeleteLineArea] may rotate whole line slices instead of copying cells
+// one by one. This requires the area to span the full width of every affected
+// line, and the fill cell to be a plain single-width cell: wide cells and their
+// zero-width placeholders need the fix-up logic in [Line.Set].
+func (b *Buffer) canRotateLines(c *Cell, area Rectangle) bool {
+	if c != nil && c.Width != 1 {
+		return false
+	}
+	width := b.Width()
+	if area.Min.X != 0 || area.Max.X != width ||
+		area.Min.Y < 0 || area.Max.Y > len(b.Lines) {
+		return false
+	}
+	for i := area.Min.Y; i < area.Max.Y; i++ {
+		if len(b.Lines[i]) != width {
+			return false
+		}
+	}
+	return true
+}
+
 // InsertLineArea inserts new lines at the given line position, with the
 // given optional cell, within the rectangle bounds. Only cells within the
 // rectangle's horizontal bounds are affected. Lines are pushed out of the
@@ -466,6 +488,26 @@ func (b *Buffer) InsertLineArea(y, n int, c *Cell, area Rectangle) {
 	// Limit number of lines to insert to available space
 	if y+n > area.Max.Y {
 		n = area.Max.Y - y
+	}
+
+	// Fast path: rotate the line slices instead of copying every cell. This is
+	// the common case (a terminal scrolling within its scroll region) and turns
+	// O(area) cell copies into O(rows) slice-header moves plus one O(width)
+	// blank fill of the line that gets recycled.
+	if b.canRotateLines(c, area) {
+		blank := EmptyCell
+		if c != nil {
+			blank = *c
+		}
+		for range n {
+			recycled := b.Lines[area.Max.Y-1]
+			copy(b.Lines[y+1:area.Max.Y], b.Lines[y:area.Max.Y-1])
+			for x := range recycled {
+				recycled[x] = blank
+			}
+			b.Lines[y] = recycled
+		}
+		return
 	}
 
 	// Move existing lines down within the bounds
@@ -497,6 +539,23 @@ func (b *Buffer) DeleteLineArea(y, n int, c *Cell, area Rectangle) {
 	// Limit deletion count to available space in scroll region
 	if n > area.Max.Y-y {
 		n = area.Max.Y - y
+	}
+
+	// Fast path: see [Buffer.InsertLineArea].
+	if b.canRotateLines(c, area) {
+		blank := EmptyCell
+		if c != nil {
+			blank = *c
+		}
+		for range n {
+			recycled := b.Lines[y]
+			copy(b.Lines[y:area.Max.Y-1], b.Lines[y+1:area.Max.Y])
+			for x := range recycled {
+				recycled[x] = blank
+			}
+			b.Lines[area.Max.Y-1] = recycled
+		}
+		return
 	}
 
 	// Shift cells up within the bounds

--- a/buffer_scroll_test.go
+++ b/buffer_scroll_test.go
@@ -1,0 +1,195 @@
+package uv
+
+import (
+	"strings"
+	"testing"
+)
+
+// newTestBuffer builds a buffer from ASCII rows, each rune becoming a
+// single-width cell.
+func newTestBuffer(rows ...string) *Buffer {
+	h := len(rows)
+	var w int
+	for _, r := range rows {
+		if len(r) > w {
+			w = len(r)
+		}
+	}
+	b := NewBuffer(w, h)
+	for y, row := range rows {
+		for x, r := range row {
+			b.SetCell(x, y, &Cell{Content: string(r), Width: 1})
+		}
+	}
+	return b
+}
+
+func TestDeleteLineArea(t *testing.T) {
+	cases := []struct {
+		name string
+		rows []string
+		y, n int
+		cell *Cell
+		area func(b *Buffer) Rectangle
+		want []string
+	}{
+		{
+			name: "scroll the whole buffer up",
+			rows: []string{"aaa", "bbb", "ccc", "ddd"},
+			y:    0, n: 1,
+			area: (*Buffer).Bounds,
+			want: []string{"bbb", "ccc", "ddd", ""},
+		},
+		{
+			name: "delete several lines",
+			rows: []string{"aaa", "bbb", "ccc", "ddd"},
+			y:    1, n: 2,
+			area: (*Buffer).Bounds,
+			want: []string{"aaa", "ddd", "", ""},
+		},
+		{
+			name: "delete more lines than the area holds",
+			rows: []string{"aaa", "bbb", "ccc"},
+			y:    1, n: 99,
+			area: (*Buffer).Bounds,
+			want: []string{"aaa", "", ""},
+		},
+		{
+			name: "stay inside a scroll region",
+			rows: []string{"aaa", "bbb", "ccc", "ddd"},
+			y:    1, n: 1,
+			area: func(b *Buffer) Rectangle { return Rect(0, 1, b.Width(), 2) },
+			want: []string{"aaa", "ccc", "", "ddd"},
+		},
+		{
+			name: "fill with the given cell",
+			rows: []string{"aaa", "bbb"},
+			y:    0, n: 1,
+			cell: &Cell{Content: "-", Width: 1},
+			area: (*Buffer).Bounds,
+			want: []string{"bbb", "---"},
+		},
+		{
+			name: "only touch cells inside a narrow area",
+			rows: []string{"abc", "def", "ghi"},
+			y:    0, n: 1,
+			area: func(b *Buffer) Rectangle { return Rect(1, 0, 1, b.Height()) },
+			want: []string{"aec", "dhf", "g i"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b := newTestBuffer(c.rows...)
+			b.DeleteLineArea(c.y, c.n, c.cell, c.area(b))
+			if got := b.String(); got != strings.Join(c.want, "\n") {
+				t.Errorf("got:\n%s\nwant:\n%s", got, strings.Join(c.want, "\n"))
+			}
+		})
+	}
+}
+
+func TestInsertLineArea(t *testing.T) {
+	cases := []struct {
+		name string
+		rows []string
+		y, n int
+		cell *Cell
+		area func(b *Buffer) Rectangle
+		want []string
+	}{
+		{
+			name: "scroll the whole buffer down",
+			rows: []string{"aaa", "bbb", "ccc", "ddd"},
+			y:    0, n: 1,
+			area: (*Buffer).Bounds,
+			want: []string{"", "aaa", "bbb", "ccc"},
+		},
+		{
+			name: "insert several lines",
+			rows: []string{"aaa", "bbb", "ccc", "ddd"},
+			y:    1, n: 2,
+			area: (*Buffer).Bounds,
+			want: []string{"aaa", "", "", "bbb"},
+		},
+		{
+			name: "insert more lines than the area holds",
+			rows: []string{"aaa", "bbb", "ccc"},
+			y:    1, n: 99,
+			area: (*Buffer).Bounds,
+			want: []string{"aaa", "", ""},
+		},
+		{
+			name: "stay inside a scroll region",
+			rows: []string{"aaa", "bbb", "ccc", "ddd"},
+			y:    1, n: 1,
+			area: func(b *Buffer) Rectangle { return Rect(0, 1, b.Width(), 2) },
+			want: []string{"aaa", "", "bbb", "ddd"},
+		},
+		{
+			name: "fill with the given cell",
+			rows: []string{"aaa", "bbb"},
+			y:    0, n: 1,
+			cell: &Cell{Content: "-", Width: 1},
+			area: (*Buffer).Bounds,
+			want: []string{"---", "aaa"},
+		},
+		{
+			name: "only touch cells inside a narrow area",
+			rows: []string{"abc", "def", "ghi"},
+			y:    0, n: 1,
+			area: func(b *Buffer) Rectangle { return Rect(1, 0, 1, b.Height()) },
+			want: []string{"a c", "dbf", "gei"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b := newTestBuffer(c.rows...)
+			b.InsertLineArea(c.y, c.n, c.cell, c.area(b))
+			if got := b.String(); got != strings.Join(c.want, "\n") {
+				t.Errorf("got:\n%s\nwant:\n%s", got, strings.Join(c.want, "\n"))
+			}
+		})
+	}
+}
+
+// TestDeleteLineAreaWideCell checks that a wide fill cell still goes through
+// [Line.Set], so its zero-width placeholders are written.
+func TestDeleteLineAreaWideCell(t *testing.T) {
+	wide := &Cell{Content: "你", Width: 2}
+
+	b := newTestBuffer("abcd", "efgh")
+	b.DeleteLineArea(0, 1, wide, b.Bounds())
+
+	if got := b.Lines[0].String(); got != "efgh" {
+		t.Errorf("line was not scrolled up: got %q, want %q", got, "efgh")
+	}
+
+	// The filled line must look like one written cell by cell through Line.Set.
+	want := make(Line, b.Width())
+	for x := range want {
+		want.Set(x, wide)
+	}
+	for x := range want {
+		if got := b.Lines[1][x]; !got.Equal(&want[x]) {
+			t.Errorf("cell (%d,1): got %+v, want %+v", x, got, want[x])
+		}
+	}
+}
+
+func BenchmarkDeleteLineArea(b *testing.B) {
+	buf := NewBuffer(120, 40)
+	cell := &Cell{Content: "x", Width: 1}
+	for y := range buf.Height() {
+		for x := range buf.Width() {
+			buf.SetCell(x, y, cell)
+		}
+	}
+	area := buf.Bounds()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		buf.DeleteLineArea(0, 1, nil, area)
+	}
+}


### PR DESCRIPTION
### Problem

`Buffer.DeleteLineArea` / `Buffer.InsertLineArea` copy every cell of the area one by one. For the common case — a terminal scrolling by one line — that is `O(width × height)` `Cell` struct copies per scrolled line, even though the content of the lines does not change; only their order does.

I ran into this while profiling a `charmbracelet/x/vt` emulator fed with a plain-text stream: `DeleteLineArea` was the top hotspot by a wide margin, because every `\n` on the bottom row copies the whole buffer.

### Change

Add a fast path to both methods: when the area spans the full width of every affected line and the fill cell is a plain single-width cell, rotate the line slices instead of copying cells. Per scrolled line this turns `O(width × height)` cell copies into `O(height)` slice-header moves plus one `O(width)` blank fill of the recycled line.

The `canRotateLines` guard keeps the existing cell-by-cell path wherever rotation would not be equivalent:

- a wide fill cell (`Width != 1`), which needs the zero-width placeholder fix-ups in `Line.Set`;
- an area narrower than the buffer;
- lines that are not all the buffer's width — rotating those would change what `Buffer.Width()` reports, since it reads `len(b.Lines[0])`.

### Benchmarks

One line scrolled off the top of a full buffer (`go test -bench . -count 6`, Go 1.25):

| buffer | before | after | speedup |
| --- | --- | --- | --- |
| 80×24 | 11.6 µs/op | 0.37 µs/op | 31× |
| 120×40 | 29.4 µs/op | 0.59 µs/op | 50× |
| 200×60 | 91.0 µs/op | 0.96 µs/op | 95× |

0 allocs/op before and after. The win grows with the buffer size because the old cost is `O(width × height)` and the new one is `O(height + width)`.

### Tests

`InsertLineArea` / `DeleteLineArea` had no test coverage, so this PR adds some: full-buffer scroll, multi-line insert/delete, clamping when `n` exceeds the area, scroll regions, a styled fill cell, a narrow sub-width area (which must keep taking the slow path), and a wide fill cell whose placeholders must still be written through `Line.Set`.

Those tests pass unchanged on `main` *before* the fast path is applied, so they characterise existing behaviour rather than new behaviour. `go test ./...` passes with the change.
