### PR TITLE
fix: paint dropped rows and preserve clusters across resizes

### DIFF
--- a/internal/conformance/fuzz_test.go
+++ b/internal/conformance/fuzz_test.go
@@ -1,6 +1,7 @@
 package conformance_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -191,15 +192,36 @@ func isKnownResidue(got, want string) bool {
 	return want != "" && got != want && strings.HasPrefix(got, want)
 }
 
+// Codepoints an emulator is known to swallow, so [FuzzScreenShowsContent] can
+// assert on everything else instead of giving up on whole clusters. Each entry
+// is a characterised emulator behaviour, not a renderer bug: keep them as tight
+// as the emulator forces and no tighter, since every rune listed here is one the
+// target can no longer catch the renderer dropping.
+const (
+	// VS16 asks for emoji presentation. ghostty's legacy width mode reads it as
+	// a hint and does not store it in the cell, so it never reads back.
+	variationSelector16 = '\ufe0f'
+	// The keycap combining mark. x/vt splits a keycap across two cells and the
+	// mark is lost from the row readback unless the cluster ends the line, so it
+	// disappears on a fresh full paint too. ghostty keeps it in both width
+	// modes, which is where the assertion still bites.
+	combiningKeycap = '\u20e3'
+)
+
 // oracles are the emulators every fuzz target runs against.
 var oracles = []struct {
-	name string
-	mk   func(*testing.T, int, int, bool) oracle
+	name  string
+	mk    func(*testing.T, int, int, bool) oracle
+	drops []rune
 }{
-	{"ghostty", newGhostty},
+	{"ghostty", newGhostty, []rune{variationSelector16}},
 	// x/vt has no legacy width mode, so its width model is fixed regardless of
 	// what the program asked for.
-	{"vt", func(t *testing.T, w, h int, _ bool) oracle { return newVT(t, w, h) }},
+	{
+		"vt",
+		func(t *testing.T, w, h int, _ bool) oracle { return newVT(t, w, h) },
+		[]rune{variationSelector16, combiningKeycap},
+	},
 }
 
 // addSeeds seeds a fuzz target from the shared corpus.
@@ -323,11 +345,19 @@ func FuzzRedrawResyncs(f *testing.F) {
 // repaint agree perfectly while both drop a glyph.
 //
 // So this target asserts something absolute instead. The most recently drawn
-// line must appear on its row, with every drift-prone cluster it contained
-// present the right number of times. It deliberately says nothing about
-// columns, because the emulators legitimately disagree about those, but "the
-// glyph reached the screen at all" is a floor that holds under every width
-// model.
+// line must appear on its row, with every codepoint of every drift-prone
+// cluster it contained present at least as many times as it was drawn.
+//
+// Codepoints are counted one at a time rather than as whole clusters because
+// the emulators disagree about how a cluster lands in cells: x/vt splits a
+// keycap across two, so the bytes are on the row but not contiguous. Counting
+// them separately keeps the assertion blind to layout and sharp about loss,
+// which matters, since dropping a combining mark is the bug this target was
+// written to catch. Where an emulator swallows a codepoint outright it is
+// listed in that oracle's drops, so the tolerance is per-emulator and named
+// rather than applied to everyone. Extra occurrences are tolerated as
+// emulator-defined residue from earlier draws. "The glyph reached the screen at
+// all" is a floor that holds under every width model.
 //
 // Only the last draw is checked, not every draw. A resize can clip rows drawn
 // earlier or shrink the screen below them, and whether clipped content should
@@ -382,13 +412,21 @@ func FuzzScreenShowsContent(f *testing.F) {
 				if want == 0 {
 					continue
 				}
-				if got := strings.Count(screen[lastY], cluster); got != want {
-					t.Errorf("%s: row %d shows %q %d times but %d were drawn\n"+
-						"  screen %q\n"+
-						"  drawn  %q\n"+
-						"program:\n%s",
-						o.name, lastY, cluster, got, want, screen[lastY], lastText, p)
-					return
+				// Count codepoints, not clusters; extras are residue.
+				for _, r := range cluster {
+					if slices.Contains(o.drops, r) {
+						continue
+					}
+					wantRune := strings.Count(lastText, string(r))
+					gotRune := strings.Count(screen[lastY], string(r))
+					if gotRune < wantRune {
+						t.Errorf("%s: row %d shows %q of cluster %q %d times but at least %d were drawn\n"+
+							"  screen %q\n"+
+							"  drawn  %q\n"+
+							"program:\n%s",
+							o.name, lastY, string(r), cluster, gotRune, wantRune, screen[lastY], lastText, p)
+						return
+					}
 				}
 			}
 		}

--- a/styled.go
+++ b/styled.go
@@ -113,9 +113,11 @@ func printString[T []byte | string](
 		tailc = *NewCell(m, tail)
 	}
 
-	decoder := ansi.DecodeSequenceWc[T]
+	// A [WidthMethod] the ansi package doesn't know about falls back to
+	// wcwidth, so the segmenter below always agrees with the decoder.
+	decoder, method := ansi.DecodeSequenceWc[T], ansi.WcWidth
 	if m == ansi.GraphemeWidth {
-		decoder = ansi.DecodeSequence[T]
+		decoder, method = ansi.DecodeSequence[T], ansi.GraphemeWidth
 	}
 
 	if s == nil {
@@ -126,8 +128,17 @@ func printString[T []byte | string](
 	var style Style
 	var link Link
 	var state byte
+	lastX, lastY := -1, -1 // last cell written, for folding in combining marks
 	for len(str) > 0 {
 		seq, width, n, newState := decoder(str, state, p)
+		// The decoder's ASCII fast path doesn't check for trailing combining
+		// sequences, so re-decode as a full cluster when one starts here.
+		// The str[1] >= 0xc0 check skips the segmenter for plain ASCII.
+		if n == 1 && seq[0] > 0x1f && seq[0] < 0x7f && len(str) > 1 && str[1] >= 0xc0 {
+			if cluster, cw := ansi.FirstGraphemeCluster(str, method); len(cluster) > 1 {
+				seq, width, n = cluster, cw, len(cluster)
+			}
+		}
 		switch width {
 		case 1, 2, 3, 4: // wide cells can go up to 4 cells wide
 			cell.Width = width
@@ -141,6 +152,7 @@ func printString[T []byte | string](
 					lines = append(lines, Line{})
 				}
 				lines[y] = append(lines[y], cell)
+				lastX, lastY = len(lines[y])-1, y
 				x += width
 			} else {
 				// Drawing to screen: handle wrapping, truncation, and bounds
@@ -158,10 +170,12 @@ func printString[T []byte | string](
 						cell.Style = style
 						cell.Link = link
 						s.SetCell(x, y, &cell)
+						lastX, lastY = x, y
 						x += tailc.Width
 					} else {
 						// Print the cell to the screen
 						s.SetCell(x, y, &cell)
+						lastX, lastY = x, y
 						x += width
 					}
 				}
@@ -194,6 +208,24 @@ func printString[T []byte | string](
 					x = 0
 				} else {
 					x = bounds.Min.X
+				}
+			case len(seq) > 0 && seq[0] >= 0xc0:
+				// A zero-width grapheme, i.e. a combining mark the re-decode
+				// above couldn't fold because an escape sequence sits between
+				// it and its base, as in "a\x1b[31m\u0301". Every escape
+				// introducer is a C0 or C1 byte, so a UTF-8 lead byte here is
+				// always text. The mark belongs to the cell we last wrote; the
+				// accumulator below would let the next glyph clobber it.
+				if s == nil {
+					if lastY >= 0 && lastY < len(lines) && lastX < len(lines[lastY]) {
+						lines[lastY][lastX].Content += string(seq)
+					}
+				} else if lastX >= 0 {
+					if prev := s.CellAt(lastX, lastY); prev != nil {
+						folded := *prev
+						folded.Content += string(seq)
+						s.SetCell(lastX, lastY, &folded)
+					}
 				}
 			default:
 				cell.Content += string(seq)

--- a/styled_test.go
+++ b/styled_test.go
@@ -2,6 +2,7 @@ package uv
 
 import (
 	"image/color"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
@@ -440,4 +441,66 @@ func newWcCell(s string, style *Style, link *Link) Cell {
 		c.Link = *link
 	}
 	return *c
+}
+
+// ASCII-heavy line: the common case. Guards the printString re-decode
+// pre-filter (str[1] >= 0xc0) from regressing plain-text draws.
+func BenchmarkPrintStringASCII(b *testing.B) {
+	line := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 4)
+	buf := NewScreenBuffer(200, 4)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewStyledString(line).Draw(buf, Rect(0, 0, 200, 1))
+	}
+}
+
+// GraphemeWidth variant of the ASCII draw, since the decoder selection
+// differs.
+func BenchmarkPrintStringASCIIGrapheme(b *testing.B) {
+	line := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 4)
+	buf := NewScreenBuffer(200, 4)
+	buf.Method = ansi.GraphemeWidth
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewStyledString(line).Draw(buf, Rect(0, 0, 200, 1))
+	}
+}
+
+// Cluster-heavy line: keycaps, VS16 emoji, combining marks. Exercises the
+// FirstGraphemeCluster re-decode path.
+func BenchmarkPrintStringClusters(b *testing.B) {
+	line := strings.Repeat("1️⃣❤️é☹️", 20)
+	buf := NewScreenBuffer(200, 4)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewStyledString(line).Draw(buf, Rect(0, 0, 200, 1))
+	}
+}
+
+func TestStyledStringCombiningMarks(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"combining mark folds into its base", "a\u0301b", []string{"a\u0301", "b"}},
+		{"keycap stays in one cell", "1\ufe0f\u20e3x", []string{"1\ufe0f\u20e3", "x"}},
+		{"style change between cells", "a\u0301\x1b[31mR", []string{"a\u0301", "R"}},
+		// The re-decode cannot fold this one, since the escape sequence sits
+		// between the base and the mark. The mark still belongs to the cell
+		// before it, and dropping it would lose the glyph.
+		{"style change between base and mark", "a\x1b[31m\u0301b", []string{"a\u0301", "b"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := NewScreenBuffer(10, 1)
+			NewStyledString(tc.in).Draw(buf, Rect(0, 0, 10, 1))
+			for x, want := range tc.want {
+				if got := buf.CellAt(x, 0).Content; got != want {
+					t.Errorf("cell %d = %q, want %q", x, got, want)
+				}
+			}
+		})
+	}
 }

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -1191,6 +1191,14 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 
 	if curWidth != newWidth || curHeight != newHeight {
 		s.oldhash, s.newhash = nil, nil
+		// A shrink makes the terminal reflow in emulator-defined ways the
+		// incremental model cannot predict; force a full repaint. Only in
+		// fullscreen, where the renderer owns every cell it is about to
+		// clear. Inline mode shares the screen with whatever came before,
+		// so it uses the narrower partial clear below instead.
+		if s.flags.Contains(tFullscreen) && (newWidth < curWidth || newHeight < curHeight) {
+			s.clear = true
+		}
 	}
 
 	// TODO: Investigate whether this is necessary. Theoretically, terminals
@@ -1219,6 +1227,12 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 		s.clearBelow(newbuf, nil, newHeight-1)
 	}
 
+	// Resize the model before diffing so the loop below walks every row
+	// of the new screen, including rows added by a grow.
+	if curWidth != newWidth || curHeight != newHeight {
+		s.curbuf.Resize(newWidth, newHeight)
+	}
+
 	if s.clear { //nolint:nestif
 		s.clearUpdate(newbuf)
 		s.clear = false
@@ -1237,14 +1251,10 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 		var changedLines int
 		var i int
 
-		if s.flags.Contains(tFullscreen) {
-			nonEmpty = min(curHeight, newHeight)
-		} else {
-			nonEmpty = newHeight
-		}
+		nonEmpty = newHeight
 
 		nonEmpty = s.clearBottom(newbuf, nonEmpty)
-		for i = 0; i < nonEmpty && i < newHeight; i++ {
+		for i = 0; i < nonEmpty; i++ {
 			if newbuf.Touched == nil || i >= len(newbuf.Touched) || (newbuf.Touched[i] != nil &&
 				(newbuf.Touched[i].FirstCell != -1 || newbuf.Touched[i].LastCell != -1)) {
 				s.transformLine(newbuf, i)
@@ -1282,15 +1292,6 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 		}
 	}
 
-	if curWidth != newWidth || curHeight != newHeight {
-		// Resize the old buffer to match the new buffer.
-		s.curbuf.Resize(newWidth, newHeight)
-		// Sync new lines to old lines
-		for i := curHeight - 1; i < newHeight; i++ {
-			copy(s.curbuf.Line(i), newbuf.Line(i))
-		}
-	}
-
 	s.updatePen(nil) // nil indicates a blank cell with no styles
 }
 
@@ -1301,9 +1302,21 @@ func (s *TerminalRenderer) Erase() {
 
 // Resize updates the terminal screen tab stops. This is used to calculate
 // terminal tab stops for hard tab optimizations.
+//
+// Resize also invalidates the cursor model when the renderer can recover
+// from it: a terminal may move the cursor on any resize, so the remembered
+// position no longer matches reality, and the next move will be absolute.
+//
+// In relative cursor mode there is no absolute move to fall back on, and
+// -1 there means "first move, assume the origin" rather than "unknown", so
+// invalidating would assert a position instead of forgetting one. Keep the
+// old model in that mode and let the next render diff against it.
 func (s *TerminalRenderer) Resize(width, _ int) {
 	if s.tabs != nil {
 		s.tabs.Resize(width)
+	}
+	if !s.flags.Contains(tRelativeCursor) {
+		s.cur.X, s.cur.Y = -1, -1
 	}
 }
 

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -3,6 +3,7 @@ package uv
 import (
 	"bytes"
 	"image/color"
+	"io"
 	"strings"
 	"testing"
 
@@ -622,7 +623,8 @@ func TestRendererSwitchBuffer(t *testing.T) {
 	}
 
 	output := buf.String()
-	expected := "\x1b[HX\r\n\n\x1b[J\x1bMX\x1b[K\r\n\n\n\n"
+	// Home, draw X at (0,0); newline, draw X at (0,1); pad cursor to row 5.
+	expected := "\x1b[HX\r\nX\r\n\n\n\n"
 	if output != expected {
 		t.Errorf("expected output after resize to be %q, got: %q", expected, output)
 	}
@@ -1335,4 +1337,147 @@ func (l *testLogger) Printf(format string, args ...interface{}) {
 	l.buf.WriteString("LOG: ")
 	l.buf.WriteString(format)
 	l.buf.WriteByte('\n')
+}
+
+// Steady-state render of a small changed region, no resize. The common
+// per-frame path.
+func BenchmarkRenderFrame(b *testing.B) {
+	r := NewTerminalRenderer(io.Discard, []string{"TERM=xterm-256color"})
+	r.SetFullscreen(true)
+	buf := NewScreenBuffer(80, 24)
+	text := NewStyledString(strings.Repeat("x", 79))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		text.Draw(buf, Rect(0, i%24, 80, 1))
+		r.Render(buf.RenderBuffer)
+	}
+}
+
+// Render across alternating grow/shrink resizes, exercising the early curbuf
+// resize and the forced clear on shrink. The buffers are built up front so the
+// measurement is the renderer's resize handling and not ScreenBuffer.Resize
+// reallocating a grid every iteration.
+func BenchmarkRenderResize(b *testing.B) {
+	sizes := [][2]int{{100, 30}, {60, 20}, {120, 40}, {80, 24}}
+	bufs := make([]ScreenBuffer, len(sizes))
+	for i, sz := range sizes {
+		bufs[i] = NewScreenBuffer(sz[0], sz[1])
+	}
+
+	r := NewTerminalRenderer(io.Discard, []string{"TERM=xterm-256color"})
+	r.SetFullscreen(true)
+	text := NewStyledString(strings.Repeat("x", 40))
+	text.Draw(bufs[0], Rect(0, 0, sizes[0][0], 1))
+	r.Render(bufs[0].RenderBuffer)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n := i % len(sizes)
+		sz, buf := sizes[n], bufs[n]
+		r.Resize(sz[0], sz[1])
+		text.Draw(buf, Rect(0, 0, sz[0], 1))
+		r.Render(buf.RenderBuffer)
+	}
+}
+
+// A resize invalidates the renderer's cursor model so the next move is
+// absolute. In relative cursor mode there is no absolute move, and -1 there
+// means "first move, assume the origin", so invalidating would assert a
+// position rather than forget one and every later row would land low.
+func TestRendererInlineResizeKeepsCursorModel(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+	r.SetRelativeCursor(true)
+	r.Resize(80, 24)
+
+	cellbuf := NewRenderBuffer(80, 3)
+	for y := range 3 {
+		cellbuf.SetCell(0, y, &Cell{Content: "a", Width: 1})
+	}
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+	buf.Reset()
+
+	// A resize event that changes nothing, as a SIGWINCH handler would send.
+	r.Resize(80, 24)
+	cellbuf.SetCell(0, 0, &Cell{Content: "b", Width: 1})
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+
+	// Cursor is on row 2 after the first render, so reaching row 0 has to move
+	// up. Without the two-row move the "b" lands on row 2.
+	expected := "\r\x1b[2Ab"
+	if output := buf.String(); output != expected {
+		t.Errorf("expected output after resize to be %q, got: %q", expected, output)
+	}
+}
+
+// A shrink forces a full repaint so the renderer does not diff against a model
+// the terminal has reflowed underneath it. Inline mode shares the screen with
+// whatever came before, so it keeps the narrower partial clear instead.
+func TestRendererInlineShrinkClearsPartially(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+	r.SetRelativeCursor(true)
+	r.Resize(80, 24)
+
+	cellbuf := NewRenderBuffer(80, 3)
+	for y := range 3 {
+		cellbuf.SetCell(0, y, &Cell{Content: "a", Width: 1})
+	}
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+	buf.Reset()
+
+	// The application gives up a row.
+	cellbuf.Resize(80, 2)
+	r.Resize(80, 24)
+	cellbuf.SetCell(0, 1, &Cell{Content: "b", Width: 1})
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+
+	// Up one row from row 2, erase the rest of the screen, redraw row 1.
+	expected := "\r\x1bM\x1b[Jb\r"
+	if output := buf.String(); output != expected {
+		t.Errorf("expected output after shrink to be %q, got: %q", expected, output)
+	}
+}
+
+// Rows added by a grow have to be diffed like any other. The model is resized
+// before the diff loop runs so the loop walks them; otherwise content drawn
+// into a new row never reaches the terminal.
+func TestRendererGrowPaintsNewRows(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+	r.SetFullscreen(true)
+	r.Resize(10, 3)
+
+	cellbuf := NewRenderBuffer(10, 3)
+	cellbuf.SetCell(0, 0, &Cell{Content: "A", Width: 1})
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+	buf.Reset()
+
+	cellbuf.Resize(10, 6)
+	r.Resize(10, 6)
+	cellbuf.SetCell(0, 5, &Cell{Content: "Z", Width: 1}) // a row the grow added
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+
+	expected := "\x1b[6;1HZ"
+	if output := buf.String(); output != expected {
+		t.Errorf("expected output after grow to be %q, got: %q", expected, output)
+	}
 }


### PR DESCRIPTION
## Why

The nightly conformance fuzzer ([run 30611521363](https://github.com/charmbracelet/ultraviolet/actions/runs/30611521363)) caught the renderer dropping content:

- **FuzzRenderer/8e096e0ae397d854**: after a fullscreen grow, rows added below the old height were never diffed, so content drawn into them never reached the terminal. The post-loop resize-and-copy then marked the content as on-screen, hiding the loss.
- **FuzzScreenShowsContent seeds #28–37**: keycap clusters lost their VS16 and combining marks. `printString` split zero-width combining sequences into phantom width-0 cells that the renderer discards, and the x/ansi decoder's ASCII fast path returned `1` without checking for trailing combiners.

Local fuzzing found two more in the same family: terminals move the cursor on resize (the renderer's cursor model went stale), and a shrink makes terminals reflow in emulator-defined ways the incremental model cannot predict.

## What changed

**`terminal_renderer.go`** — resize `curbuf` before diffing so every row of a grown screen is walked. Invalidate the cursor model in `Resize`, and force a full repaint on shrink, both scoped to the mode that can act on them:

- The invalidation is for absolute-cursor mode only. In relative cursor mode `-1` is `moveCursor`'s first-move sentinel, not an unknown, so invalidating there asserts the origin rather than forgetting a position and every inline row after a resize lands low. Even a resize that changes nothing corrupts it, and `TerminalScreen.Resize` forwards every resize event.
- The shrink repaint is for fullscreen only, where the renderer owns every cell it clears. Its guard was otherwise a superset of the inline partial clear below it, leaving that branch unreachable, and a full clear in inline mode erases rows the renderer does not own.

**`styled.go`** — re-decode ASCII fast-path bytes with `FirstGraphemeCluster` when a longer cluster actually starts there, gated on a `>= 0xc0` lead byte so plain-ASCII draws skip the segmenter. The segmenter's width method now falls out of the same branch as the decoder instead of a type assertion, so a `WidthMethod` from outside the ansi package gets wcwidth for both rather than silently skipping the fold. A mark the re-decode cannot reach, because an escape sequence sits between it and its base as in `"a\x1b[31ḿ"`, folds into the cell it belongs to; the zero-width accumulator previously let the next glyph clobber it.

Note this makes `WcWidth` mode grapheme-cluster an ASCII base with its combining marks, where before it emitted them as separate cells. That is a width-model change, and it matches what terminals do in both modes.

**`internal/conformance/fuzz_test.go`** — `FuzzScreenShowsContent` counts each codepoint of a drift cluster rather than the cluster itself, since the emulators disagree about how one lands in cells (x/vt splits a keycap across two, so the bytes are present but not contiguous). Codepoints an emulator swallows outright are listed per oracle rather than tolerated for everyone: VS16 for both, the keycap mark for x/vt, which loses it on a fresh full paint too. Asserting only on the base codepoint would no longer fail when a renderer drops every combining mark, which is the bug this target exists to catch.

**`terminal_renderer_test.go`, `styled_test.go`** — regression tests for the grow, the inline cursor model, the inline shrink clear, and cluster folding. `TestRendererSwitchBuffer`'s expectation is updated (strictly shorter output) with an explanatory comment. Benchmarks for the touched paths live next to their subjects; the resize benchmark builds its buffers up front so it measures the renderer and not `ScreenBuffer.Resize`.

## Verification

- Full test suite, conformance suite, `go vet` and `golangci-lint` across both modules: clean.
- Conformance was run against a locally built libghostty-vt, not just CI. Tightening the assertion immediately failed seeds #34–37; probing a fresh full paint showed the cause is x/vt rather than the renderer, which is what the per-oracle `drops` list records:

  ```
  vt      gw=true   -> "111️⃣"
  ghostty gw=true   -> "1️⃣1️⃣1️⃣"
  ghostty gw=false  -> "1⃣1⃣1⃣"     (VS16 consumed, keycap mark kept)
  ```

- Two-minute fuzz runs per target. `FuzzRedrawResyncs` clean at 650k execs. The other two found two new crashers, both skin-tone emoji, both reproducing before this branch, so they belong to the pre-existing class below and are not committed.
- Benchmarks, interleaved min-of-8: plain-ASCII draws identical, cluster-heavy within a couple of percent on the mean. Resize-every-frame is slower than main, the cost of the shrink repaint and the grow fix, which previously did the wrong thing cheaply; at a realistic cadence of 1 resize per 100 frames the difference is not statistically detectable.

One pre-existing crasher class remains out of scope: skin-tone emoji width disagreement between `WcWidth` and ghostty-legacy's per-codepoint summing, already documented in `internal/conformance/program.go`.

💘 Generated with Crush
