### PR TITLE
fix: draw graphene clusters wider than 4 columns  

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/charmbracelet/x/mosaic v0.0.0-20250509021451-13796e822d86
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/lucasb-eyer/go-colorful v1.4.0
-	github.com/mattn/go-runewidth v0.0.23
+	github.com/mattn/go-runewidth v0.0.24
 	github.com/rivo/uniseg v0.4.7
 )
 
 require (
-	github.com/bits-and-blooms/bitset v1.24.4 // indirect
+	github.com/bits-and-blooms/bitset v1.24.6 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
@@ -28,3 +28,5 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )
+
+replace github.com/charmbracelet/x/ansi => ../../x/ansi

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -7,10 +7,10 @@ replace github.com/charmbracelet/ultraviolet => ../
 require (
 	charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106193318-19329a3e8410
 	github.com/charmbracelet/ultraviolet v0.0.0-20251106190538-99ea45596692
-	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/mosaic v0.0.0-20250509021451-13796e822d86
 	github.com/charmbracelet/x/term v0.2.2
-	github.com/lucasb-eyer/go-colorful v1.4.0
+	github.com/lucasb-eyer/go-colorful v1.4.1
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/rivo/uniseg v0.4.7
 )
@@ -28,5 +28,3 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )
-
-replace github.com/charmbracelet/x/ansi => ../../x/ansi

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,11 +1,9 @@
 charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106193318-19329a3e8410 h1:D9PbaszZYpB4nj+d6HTWr1onlmlyuGVNfL9gAi8iB3k=
 charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106193318-19329a3e8410/go.mod h1:1qZyvvVCenJO2M1ac2mX0yyiIZJoZmDM4DG4s0udJkU=
-github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
-github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bitset v1.24.6 h1:qcrftZUVBIwfs+m+nhoCBAPT+ZPZZjti8SbHbDQQkZ4=
+github.com/bits-and-blooms/bitset v1.24.6/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
-github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/mosaic v0.0.0-20250509021451-13796e822d86 h1:HB9sj5+xpjPe3DRwI+AK8vDvNGr+DtMkrPs+TXyjNEU=
 github.com/charmbracelet/x/mosaic v0.0.0-20250509021451-13796e822d86/go.mod h1:5qLP4S++M5quSc/xbvWWW8vKkgKwOqOT/IVhAas26XI=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
@@ -20,8 +18,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
-github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
+github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -4,6 +4,8 @@ github.com/bits-and-blooms/bitset v1.24.6 h1:qcrftZUVBIwfs+m+nhoCBAPT+ZPZZjti8Sb
 github.com/bits-and-blooms/bitset v1.24.6/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
+github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
+github.com/charmbracelet/x/ansi v0.11.8/go.mod h1:ZNN+3mXny/516oTQPLMPIBeSINvNJJQ8uQXDgbeJxY0=
 github.com/charmbracelet/x/mosaic v0.0.0-20250509021451-13796e822d86 h1:HB9sj5+xpjPe3DRwI+AK8vDvNGr+DtMkrPs+TXyjNEU=
 github.com/charmbracelet/x/mosaic v0.0.0-20250509021451-13796e822d86/go.mod h1:5qLP4S++M5quSc/xbvWWW8vKkgKwOqOT/IVhAas26XI=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
@@ -16,8 +18,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
-github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
-github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/lucasb-eyer/go-colorful v1.4.1 h1:1EO+WB73+EH8EVbzlrG3KLAfEypQWVHIBqlTf+2hNss=
+github.com/lucasb-eyer/go-colorful v1.4.1/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
 github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=

--- a/examples/widths/main.go
+++ b/examples/widths/main.go
@@ -1,0 +1,120 @@
+// Command widths renders scripts and emoji whose column width the two width
+// models disagree about, so drift between what ultraviolet thinks it drew and
+// what the terminal actually painted is visible on screen.
+//
+// Every sample sits in a box of the same inner width, padded out using
+// ultraviolet's own measurement. If the width model matches the terminal, the
+// right edges form a straight column. Any edge that sits left or right of the
+// rest is the renderer and the terminal disagreeing about that sample, which is
+// the bug this example exists to show.
+//
+// Press w to force wcwidth, g to force grapheme width, q to quit. Terminals
+// that implement DEC mode 2027 line up under grapheme width; everything else
+// lines up under wcwidth.
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+)
+
+var samples = []struct {
+	name string
+	text string
+}{
+	{"ascii", "hello world"},
+	{"hindi", "नमस्ते दुनिया"},
+	{"hindi conjunct", "स्ते क्ष त्र ज्ञ"},
+	{"combining", "café résumé"},
+	{"cjk", "世界你好"},
+	{"emoji", "🌈 🔥 🦄"},
+	{"zwj family", "👨‍👩‍👧‍👦"},
+	{"zwj work", "👨‍💻 👩‍🚀"},
+	{"zwj flag", "🏳️‍🌈"},
+	{"skin tone", "👍🏽 👋🏿"},
+	{"vs16", "⚠️ ❤️ ✈️"},
+	{"keycap", "1️⃣ 2️⃣ 3️⃣"},
+	{"flags", "🇺🇸 🇯🇵"},
+}
+
+// boxWidth is the inner width every sample is padded to.
+const boxWidth = 24
+
+func main() {
+	t := uv.DefaultTerminal()
+	scr := t.Screen()
+
+	if err := t.Start(); err != nil {
+		log.Fatalf("failed to start: %v", err)
+	}
+	defer t.Stop() //nolint:errcheck
+
+	scr.EnterAltScreen()
+
+	// forced reports whether the width method was pinned from the keyboard,
+	// which is what makes the two models comparable on the same terminal.
+	var forced string
+
+	display := func() {
+		var b strings.Builder
+
+		method := "wcwidth"
+		if scr.WidthMethod() == ansi.GraphemeWidth {
+			method = "grapheme (DEC mode 2027)"
+		}
+		fmt.Fprintf(&b, "width method: %s", method)
+		if forced != "" {
+			fmt.Fprintf(&b, "  [forced with %q]", forced)
+		}
+		b.WriteString("\n")
+		b.WriteString("the right edges below should form one straight column\n\n")
+
+		// A ruler, so a drifting edge can be read off in columns.
+		ruler := strings.Repeat("....|....+", (boxWidth+12)/10+1)
+		b.WriteString(ruler[:boxWidth+2] + "\n")
+
+		for _, s := range samples {
+			w := scr.StringWidth(s.text)
+			pad := boxWidth - w
+			if pad < 0 {
+				pad = 0
+			}
+			fmt.Fprintf(&b, "│%s%s│ uv=%-2d ansi=%-2d  %s\n",
+				s.text, strings.Repeat(" ", pad), w,
+				ansi.StringWidth(s.text), s.name)
+		}
+
+		b.WriteString("\nw: force wcwidth   g: force grapheme width   q: quit")
+
+		uv.NewStyledString(b.String()).Draw(scr, scr.Bounds())
+		scr.Render() //nolint:errcheck
+		scr.Flush()  //nolint:errcheck
+	}
+
+	display()
+
+	for ev := range t.Events() {
+		switch ev := ev.(type) {
+		case uv.WindowSizeEvent:
+			scr.Resize(ev.Width, ev.Height)
+			display()
+		case uv.KeyPressEvent:
+			switch {
+			case ev.MatchString("w"):
+				scr.SetWidthMethod(ansi.WcWidth)
+				forced = "w"
+				display()
+			case ev.MatchString("g"):
+				scr.SetWidthMethod(ansi.GraphemeWidth)
+				forced = "g"
+				display()
+			default:
+				return
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,11 @@ require (
 	golang.org/x/sys v0.47.0
 )
 
-require github.com/clipperhouse/displaywidth v0.11.0 // indirect
-
 require (
-	github.com/lucasb-eyer/go-colorful v1.4.1
-	github.com/mattn/go-runewidth v0.0.23 // indirect
+	github.com/clipperhouse/displaywidth v0.11.0 // indirect
+	github.com/mattn/go-runewidth v0.0.24 // indirect
 )
+
+require github.com/lucasb-eyer/go-colorful v1.4.1
+
+replace github.com/charmbracelet/x/ansi => ../x/ansi

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/charmbracelet/colorprofile v0.4.3
-	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/charmbracelet/x/termios v0.1.1
 	github.com/charmbracelet/x/windows v0.2.2
@@ -22,5 +22,3 @@ require (
 )
 
 require github.com/lucasb-eyer/go-colorful v1.4.1
-
-replace github.com/charmbracelet/x/ansi => ../x/ansi

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
+github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
+github.com/charmbracelet/x/ansi v0.11.8/go.mod h1:ZNN+3mXny/516oTQPLMPIBeSINvNJJQ8uQXDgbeJxY0=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
-github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=
@@ -14,8 +12,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/lucasb-eyer/go-colorful v1.4.1 h1:1EO+WB73+EH8EVbzlrG3KLAfEypQWVHIBqlTf+2hNss=
 github.com/lucasb-eyer/go-colorful v1.4.1/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
-github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
+github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/conformance/fuzz_test.go
+++ b/internal/conformance/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/ultraviolet/internal/conformance"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // runner drives one fuzz program against one emulator.
@@ -39,11 +40,19 @@ func newRunner(t *testing.T, p conformance.Program, mk func(*testing.T, int, int
 	rend.SetScrollOptim(p.ScrollOptim)
 	rend.Erase()
 
+	// The buffer and the renderer must measure width the same way, otherwise
+	// the cells the renderer is asked to draw have widths it did not expect.
+	// The emulator follows the same flag, so all three agree.
+	buf := uv.NewScreenBuffer(p.Width, p.Height)
+	if p.GraphemeWidth {
+		buf.Method = ansi.GraphemeWidth
+	}
+
 	return &runner{
 		prog: p,
 		rend: rend,
 		term: term,
-		buf:  uv.NewScreenBuffer(p.Width, p.Height),
+		buf:  buf,
 		w:    p.Width,
 		h:    p.Height,
 	}
@@ -158,14 +167,6 @@ func compare(t *testing.T, p conformance.Program, what string, got, want []strin
 		if got[y] == want[y] {
 			continue
 		}
-		if isKnownResidue(got[y], want[y]) {
-			t.Skipf("known issue: a shrinking line leaves cluster residue behind\n"+
-				"  %s, row %d\n"+
-				"  got  %q\n"+
-				"  want %q\n"+
-				"program:\n%s",
-				what, y, got[y], want[y], p)
-		}
 		t.Errorf("%s: screen disagrees with a full repaint at row %d\n"+
 			"  got  %q\n"+
 			"  want %q\n"+
@@ -173,23 +174,6 @@ func compare(t *testing.T, p conformance.Program, what string, got, want []strin
 			what, y, got[y], want[y], p)
 		return
 	}
-}
-
-// isKnownResidue reports whether a mismatch is the already-characterised bug
-// where a shrinking line leaves the tail of a cluster behind.
-//
-// This exists because fuzzing cannot start past a failing seed: Go checks the
-// whole seed corpus before it begins mutating, so a single known bug blocks the
-// search for every unknown one. Recognising the known failure keeps the targets
-// fuzzable while leaving the expectation written down, and
-// TestKnownResidueStillReproduces fails once the bug is fixed, so the allowance
-// gets removed rather than quietly masking a later regression.
-//
-// The rule is deliberately narrow: the incremental screen must still contain the
-// entire expected row, with extra content only after it. Anything that erases or
-// shifts content fails as normal.
-func isKnownResidue(got, want string) bool {
-	return want != "" && got != want && strings.HasPrefix(got, want)
 }
 
 // Codepoints an emulator is known to swallow, so [FuzzScreenShowsContent] can

--- a/internal/conformance/go.mod
+++ b/internal/conformance/go.mod
@@ -27,3 +27,5 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )
+
+replace github.com/charmbracelet/x/ansi => ../../../x/ansi

--- a/internal/conformance/go.mod
+++ b/internal/conformance/go.mod
@@ -6,7 +6,7 @@ replace github.com/charmbracelet/ultraviolet => ../..
 
 require (
 	github.com/charmbracelet/ultraviolet v0.0.0-20260303162955-0b88c25f3fff
-	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/vt v0.0.0-20260727090823-41c9e6be3365
 	go.mitchellh.com/libghostty v0.0.0-20260727203050-ef0f8ce3daa7
 )
@@ -19,13 +19,11 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
+	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
+	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )
-
-replace github.com/charmbracelet/x/ansi => ../../../x/ansi

--- a/internal/conformance/go.sum
+++ b/internal/conformance/go.sum
@@ -1,7 +1,7 @@
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
-github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
+github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
+github.com/charmbracelet/x/ansi v0.11.8/go.mod h1:ZNN+3mXny/516oTQPLMPIBeSINvNJJQ8uQXDgbeJxY0=
 github.com/charmbracelet/x/exp/ordered v0.1.0 h1:55/qLwjIh0gL0Vni+QAWk7T/qRVP6sBf+2agPBgnOFE=
 github.com/charmbracelet/x/exp/ordered v0.1.0/go.mod h1:5UHwmG+is5THxMyCJHNPCn2/ecI07aKNrW+LcResjJ8=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
@@ -16,10 +16,10 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
-github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
-github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
-github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/lucasb-eyer/go-colorful v1.4.1 h1:1EO+WB73+EH8EVbzlrG3KLAfEypQWVHIBqlTf+2hNss=
+github.com/lucasb-eyer/go-colorful v1.4.1/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
+github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/conformance/program_test.go
+++ b/internal/conformance/program_test.go
@@ -181,28 +181,3 @@ func TestFuzzTargetsRunSeeds(t *testing.T) {
 	t.Log("go test runs each FuzzXxx target over its seeds; " +
 		"use -fuzz to search for new inputs")
 }
-
-// TestIsKnownResidueIsNarrow pins down the allowance that lets fuzzing start.
-//
-// isKnownResidue suppresses a real failure, so it has to stay tight. If it ever
-// widened to match erased or shifted content it would hide exactly the bugs
-// these targets exist to find, and nothing else would notice.
-func TestIsKnownResidueIsNarrow(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		got, want string
-		known     bool
-	}{
-		{"identical rows are not a failure at all", "ab", "ab", false},
-		{"trailing residue is the known bug", "a\u26d3\ufe0f\u200d\U0001f4a5\U0001f4a5", "a\u26d3\ufe0f\u200d\U0001f4a5", true},
-		{"erased content must still fail", "a", "a\u26d3\ufe0f\u200d\U0001f4a5", false},
-		{"shifted content must still fail", " ab", "ab", false},
-		{"a wholly different row must still fail", "xy", "ab", false},
-		{"an empty expectation must never be excused", "junk", "", false},
-	} {
-		if got := isKnownResidue(tc.got, tc.want); got != tc.known {
-			t.Errorf("%s: isKnownResidue(%q, %q) = %v, want %v",
-				tc.name, tc.got, tc.want, got, tc.known)
-		}
-	}
-}

--- a/key_test.go
+++ b/key_test.go
@@ -529,7 +529,7 @@ func TestParseSequence(t *testing.T) {
 		seqTest{
 			[]byte("\x1b_Gi=1337,q=1;EINVAL:your face\x1b\\"),
 			[]Event{KittyGraphicsEvent{
-				Options: kitty.Options{ID: 1337, Quite: 1},
+				Options: kitty.Options{ID: 1337, Quiet: 1},
 				Payload: []byte("EINVAL:your face"),
 			}},
 		},

--- a/styled.go
+++ b/styled.go
@@ -139,8 +139,13 @@ func printString[T []byte | string](
 				seq, width, n = cluster, cw, len(cluster)
 			}
 		}
-		switch width {
-		case 1, 2, 3, 4: // wide cells can go up to 4 cells wide
+		switch {
+		// Any positive width is a printable grapheme cluster. Wcwidth measures
+		// a cluster per codepoint, so this is not bounded by how wide a glyph
+		// can be: a ZWJ emoji sequence such as "👨‍👩‍👧‍👦" is eight columns,
+		// and capping the width here would fall through to the escape sequence
+		// branch and drop the cluster from the screen.
+		case width > 0:
 			cell.Width = width
 			cell.Content = string(seq)
 			cell.Style = style

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -808,6 +808,64 @@ func (s *TerminalRenderer) el0Cost() int {
 	return len(ansi.EraseLineRight)
 }
 
+// lineHasDrift reports whether the line contains a cell that a cell-level
+// diff cannot safely reposition across: a wide cell (width > 1), or a cell
+// whose width the terminal may measure differently than the model. Wide cells
+// occupy several columns, so a diff that lands on a continuation column splits
+// the character; and a width disagreement means the model cannot know which
+// column each glyph landed on.
+func lineHasDrift(m ansi.Method, line Line) bool {
+	for i := 0; i < len(line); i++ {
+		c := line.At(i)
+		if c == nil || c.Width == 0 || len(c.Content) == 0 {
+			continue
+		}
+		if c.Width > 1 || m.StringWidth(c.Content) != ansi.StringWidth(c.Content) {
+			return true
+		}
+	}
+	return false
+}
+
+// repaintLine repaints a line from scratch. Unlike
+// [TerminalRenderer.transformLine] it does not diff against the previous
+// frame: it erases the whole line from column 0 with [ansi.EraseLineRight]
+// and then writes the new frame's cells. Erasing from column 0 removes the
+// entire line including any wide cells the terminal painted at a different
+// width than the model measured, whose real extent the model cannot know.
+// The repaint then starts from a known-empty line and an absolute cursor
+// position, so the result does not depend on where the previous frame left
+// the cursor.
+func (s *TerminalRenderer) repaintLine(newbuf *RenderBuffer, y int) {
+	oldLine := s.curbuf.Line(y)
+	newLine := newbuf.Line(y)
+
+	s.move(newbuf, 0, y)
+	blank := s.clearBlank()
+	s.updatePen(blank)
+	_, _ = s.buf.WriteString(ansi.EraseLineRight)
+	s.cur.X = 0
+
+	// Write the content cells. The line was just erased, so trailing blanks
+	// need no write, and writing them would risk wrapping past the right
+	// margin if the terminal painted a wide cell wider than the model
+	// measured.
+	last := -1
+	for x := 0; x < newbuf.Width(); x++ {
+		if c := newLine.At(x); c != nil && !c.isWidePlaceholder() && !cellEqual(c, blank) {
+			last = x
+		}
+	}
+	for x := 0; x <= last; x++ {
+		s.putCell(newbuf, newLine.At(x))
+	}
+
+	// Adopt the new line as the model of what is on screen.
+	if len(oldLine) == len(newLine) {
+		copy(oldLine, newLine)
+	}
+}
+
 // transformLine transforms the given line in the current window to the
 // corresponding line in the new window. It uses [ansi.ICH] and [ansi.DCH] to
 // insert or delete characters.
@@ -818,6 +876,22 @@ func (s *TerminalRenderer) transformLine(newbuf *RenderBuffer, y int) {
 
 	s.lineHadWide = false
 	defer s.reanchorWideLine(newbuf)
+
+	// If either frame's line holds a cell that a cell-level diff cannot
+	// safely reposition across, repaint the whole line instead. A wide cell
+	// (width > 1) occupies several columns, so a diff that lands on a
+	// continuation column splits the character, and per DEC semantics (also
+	// implemented by ghostty and x/vt) an erase that splits a multi-cell
+	// character erases the whole character, including a head cell that
+	// belongs to the new frame. A cell whose width the terminal measures
+	// differently than the model (an emoji cluster, a keycap) leaves the
+	// real cursor at a column the model cannot predict, so a later erase in
+	// the same transform fires at the wrong column. Repainting depends only
+	// on an absolute cursor position and a known-empty line.
+	if lineHasDrift(s.method, oldLine) || lineHasDrift(s.method, newLine) {
+		s.repaintLine(newbuf, y)
+		return
+	}
 
 	// Find the first changed cell in the line
 	blank := newLine.At(0)

--- a/width_test.go
+++ b/width_test.go
@@ -1,0 +1,112 @@
+package uv
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestDrawWcWidthCells checks that drawing lays cells out over the same number
+// of columns the terminal advances over. A cell holds a whole grapheme
+// cluster, but under wcwidth its width is the sum of the cluster's codepoints,
+// which is what a terminal without Unicode core mode (DEC mode 2027) advances
+// by. Get that wrong and every cell after it lands in the wrong column.
+func TestDrawWcWidthCells(t *testing.T) {
+	tests := []struct {
+		name   string
+		str    string
+		widths []int // width of each non-placeholder cell, in order
+	}{
+		{"ascii", "abc", []int{1, 1, 1}},
+		{"combining acute", "éx", []int{1, 1}},
+		{"devanagari", "नमस्ते", []int{1, 1, 2}},
+		{"cjk", "世界", []int{2, 2}},
+		{"vs16", "⚠️", []int{1}},
+		{"zwj pair", "👨‍💻", []int{4}},
+		{"zwj flag", "🏳️‍🌈", []int{3}},
+		{"skin tone", "👍🏽", []int{4}},
+		// Wider than any glyph, and wider than the four columns cells used to
+		// be capped at. A capped cluster ends up zero width, which the
+		// renderer skips as a wide-cell placeholder, so it never gets drawn.
+		{"zwj family", "👨‍👩‍👧‍👦", []int{8}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := NewScreenBuffer(20, 1)
+			buf.Method = ansi.WcWidth
+			NewStyledString(tc.str).Draw(buf, buf.Bounds())
+
+			var x int
+			for i, want := range tc.widths {
+				cell := buf.CellAt(x, 0)
+				if cell == nil {
+					t.Fatalf("cell %d: no cell at column %d", i, x)
+				}
+				if cell.Width != want {
+					t.Errorf("cell %d: width %d, want %d", i, cell.Width, want)
+				}
+				// Every column the cell covers past the first has to be a
+				// placeholder, otherwise the buffer and the terminal disagree
+				// about what occupies them.
+				for j := 1; j < cell.Width; j++ {
+					if p := buf.CellAt(x+j, 0); p == nil || !p.isWidePlaceholder() {
+						t.Errorf("column %d: got %+v, want a wide placeholder", x+j, p)
+					}
+				}
+				x += max(cell.Width, 1)
+			}
+
+			if got := ansi.StringWidthWc(tc.str); got != x {
+				t.Errorf("cells cover %d columns, but the string measures %d", x, got)
+			}
+		})
+	}
+}
+
+// TestDrawGraphemeWidthCells covers the same strings under the width model of
+// a terminal in Unicode core mode, which measures a cluster as the one glyph
+// it draws.
+func TestDrawGraphemeWidthCells(t *testing.T) {
+	tests := []struct {
+		str   string
+		width int // width of the first cell
+	}{
+		{"नमस्ते", 1},
+		{"⚠️", 2},
+		{"👨‍👩‍👧‍👦", 2},
+		{"👍🏽", 2},
+	}
+
+	for _, tc := range tests {
+		buf := NewScreenBuffer(20, 1)
+		buf.Method = ansi.GraphemeWidth
+		NewStyledString(tc.str).Draw(buf, buf.Bounds())
+
+		cell := buf.CellAt(0, 0)
+		if cell == nil {
+			t.Fatalf("%q: no cell at column 0", tc.str)
+		}
+		if cell.Width != tc.width {
+			t.Errorf("%q: width %d, want %d", tc.str, cell.Width, tc.width)
+		}
+	}
+}
+
+// TestNewCellWidths checks that cells built directly agree with the cells
+// [StyledString] lays out.
+func TestNewCellWidths(t *testing.T) {
+	for _, tc := range []struct {
+		gr   string
+		want int
+	}{
+		{"a", 1},
+		{" ", 1},
+		{"स्ते", 2},
+		{"👨‍💻", 4},
+	} {
+		if got := NewCell(ansi.WcWidth, tc.gr).Width; got != tc.want {
+			t.Errorf("NewCell(WcWidth, %q).Width = %d, want %d", tc.gr, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What?

`printString` accepted cell widths of 1 through 4 and treated anything else as a non-printable sequence. Any positive width is now a printable cluster.

## Why?

Fixes charmbracelet/bubbletea#1737 (after charmbracelet/x#933 merge and `ansi` release)

Fixes CHARM-1896