### PR TITLE
fix: preserve zero-width graphemes in the cell round-trip

### DIFF
--- a/styled.go
+++ b/styled.go
@@ -131,7 +131,10 @@ func printString[T []byte | string](
 		switch width {
 		case 1, 2, 3, 4: // wide cells can go up to 4 cells wide
 			cell.Width = width
-			cell.Content = string(seq)
+			// Prepend any accumulated zero-width graphemes (ZWNJ, ZWSP,
+			// combining marks decoded as width-0 sequences) so they survive
+			// the cell round-trip instead of being clobbered.
+			cell.Content = cell.Content + string(seq)
 			cell.Style = style
 			cell.Link = link
 

--- a/styled_test.go
+++ b/styled_test.go
@@ -376,6 +376,34 @@ func TestStyledString(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "zero-width graphemes preserved",
+			input:          "a\u200bb",
+			expectedWidth:  2,
+			expectedHeight: 1,
+			expected: &Buffer{
+				Lines: []Line{
+					{
+						newWcCell("a", nil, nil),
+						newWcCell("\u200bb", nil, nil),
+					},
+				},
+			},
+		},
+		{
+			name:           "combining mark preserved",
+			input:          "e\u0301x",
+			expectedWidth:  2,
+			expectedHeight: 1,
+			expected: &Buffer{
+				Lines: []Line{
+					{
+						newWcCell("e", nil, nil),
+						newWcCell("\u0301x", nil, nil),
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
## Problem

`printString` (styled.go) drops zero-width graphemes when decomposing a styled string into cells. Width-0 sequences (ZWNJ U+200C, ZWSP U+200B, combining marks that decode as width-0) are accumulated into the pending cell in the `default` branch (`cell.Content += string(seq)`), but the next visible cell **overwrites** them:

```go
case 1, 2, 3, 4:
    cell.Width = width
    cell.Content = string(seq)  // clobbers the accumulated zero-width graphemes
```

So any content containing a standalone width-0 grapheme loses it on the round-trip. A decomposed accent renders wrong: `"e\u0301x"` comes back as `"ex"`.

## Repro

```go
ss := uv.NewStyledString("e\u0301x")
area := ss.Bounds()
buf := uv.NewScreenBuffer(area.Dx(), area.Dy())
ss.Draw(buf, area)
// buf.Lines[0] is [ {e}, {x} ] — the combining acute is gone
```

## Fix

Prepend the accumulated zero-width content to the next visible cell instead of overwriting it. Input order is preserved (the accumulated sequences precede the visible grapheme in the input), cell widths are unchanged, and the end-of-string flush already emits a trailing width-0 cell, so trailing graphemes survive too.

## Test

Two cases added to `TestStyledString`: ZWSP between two letters and a combining mark before a letter. Both fail on `main` and pass with the fix.

## Context

Found while building a TUI editor: the canvas round-trip (lipgloss layer compositing) silently stripped ZWNJ and combining marks from editor content every frame. Note that #95 is adjacent (unknown escape sequences are dropped in the same `default` branch) but is a separate bug.
