### PR TITLE
fix: pace bursts of non-printable key events

### DIFF
--- a/key_test.go
+++ b/key_test.go
@@ -923,6 +923,74 @@ func TestReadLongInput(t *testing.T) {
 	}
 }
 
+func TestReadNonPrintableBurstIsPaced(t *testing.T) {
+	const n = 8
+	input := strings.Repeat("\x1b[A", n)
+	rdr := strings.NewReader(input)
+	drv := NewTerminalReader(rdr, "dumb")
+
+	eventc := make(chan Event)
+	go func() {
+		defer close(eventc)
+		if err := drv.StreamEvents(context.TODO(), eventc); err != nil {
+			t.Errorf("error streaming events: %v", err)
+		}
+	}()
+
+	var times []time.Time
+	for ev := range eventc {
+		kp, ok := ev.(KeyPressEvent)
+		if !ok || kp.Code != KeyUp {
+			t.Fatalf("expected up arrow key event, got %#v", ev)
+		}
+		times = append(times, time.Now())
+	}
+	if len(times) != n {
+		t.Fatalf("expected %d events, got %d", n, len(times))
+	}
+
+	// Bursts of non-printable key events are dispatched with a delay between
+	// each event so that frame-based renderers can present intermediate states
+	// instead of collapsing the burst into a single frame.
+	want := time.Duration(n-1) * EventDispatchInterval
+	if got := times[len(times)-1].Sub(times[0]); got < want {
+		t.Errorf("expected dispatch of %d events to take at least %v, took %v", n, want, got)
+	}
+}
+
+func TestReadPrintableBurstIsNotPaced(t *testing.T) {
+	const n = 1000
+	input := strings.Repeat("a", n)
+	rdr := strings.NewReader(input)
+	drv := NewTerminalReader(rdr, "dumb")
+
+	eventc := make(chan Event)
+	start := time.Now()
+	go func() {
+		defer close(eventc)
+		if err := drv.StreamEvents(context.TODO(), eventc); err != nil {
+			t.Errorf("error streaming events: %v", err)
+		}
+	}()
+
+	count := 0
+	for ev := range eventc {
+		if kp, ok := ev.(KeyPressEvent); ok && kp.Text == "a" {
+			count++
+		}
+	}
+	elapsed := time.Since(start)
+	if count != n {
+		t.Fatalf("expected %d events, got %d", n, count)
+	}
+
+	// Printable text is dispatched immediately to avoid slowing down typing
+	// and pasting. Pacing it would take ~20 seconds for this burst.
+	if elapsed >= EventDispatchInterval*5 {
+		t.Errorf("expected printable text burst to dispatch immediately, took %v", elapsed)
+	}
+}
+
 func TestReadInput(t *testing.T) {
 	type test struct {
 		keyname string

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -26,6 +26,15 @@ var ErrReaderNotStarted = fmt.Errorf("reader not started")
 // process ESC sequences. It is set to 50 milliseconds.
 const DefaultEscTimeout = 50 * time.Millisecond
 
+// EventDispatchInterval is the minimum delay between dispatching events decoded
+// from the same input buffer. Frame-based renderers, like the one used by
+// Bubble Tea, render at a fixed rate (60 fps) and only display the state of the
+// program at the moment they flush. Without this delay, a burst of input (such
+// as an auto-repeating key) would be processed within a single frame and only
+// the first and last states would ever be visible. Pacing the dispatch lets the
+// renderer present each intermediate state.
+const EventDispatchInterval = 20 * time.Millisecond
+
 // TerminalReader represents an input event loop that reads input events from
 // a reader and parses them into human-readable events. It supports
 // reading escape sequences, mouse events, and bracketed paste mode.
@@ -161,11 +170,11 @@ func (d *TerminalReader) StreamEvents(ctx context.Context, eventc chan<- Event) 
 	for {
 		select {
 		case <-ctx.Done():
-			d.sendEvents(eventc, buf.Bytes(), true)
+			d.sendEvents(ctx, eventc, buf.Bytes(), true)
 			wg.Wait()
 			return nil
 		case err := <-errc:
-			d.sendEvents(eventc, buf.Bytes(), true)
+			d.sendEvents(ctx, eventc, buf.Bytes(), true)
 			wg.Wait()
 			return err // return the first error encountered
 		case <-timeout.C:
@@ -176,7 +185,7 @@ func (d *TerminalReader) StreamEvents(ctx context.Context, eventc chan<- Event) 
 			timedout := time.Now().After(ttimeout)
 			if buf.Len() > 0 && timedout {
 				d.logf("timeout expired, processing buffer")
-				n = d.sendEvents(eventc, buf.Bytes(), true)
+				n = d.sendEvents(ctx, eventc, buf.Bytes(), true)
 			}
 
 			if n > 0 {
@@ -200,7 +209,7 @@ func (d *TerminalReader) StreamEvents(ctx context.Context, eventc chan<- Event) 
 			d.logf("input: %q", read)
 			buf.Write(read)
 			ttimeout = time.Now().Add(d.EscTimeout)
-			n := d.sendEvents(eventc, buf.Bytes(), false)
+			n := d.sendEvents(ctx, eventc, buf.Bytes(), false)
 			if !timeout.Stop() {
 				// drain the channel if it was already running
 				select {
@@ -228,12 +237,37 @@ func (d *TerminalReader) SetLogger(logger Logger) {
 	d.logger = logger
 }
 
-func (d *TerminalReader) sendEvents(eventc chan<- Event, buf []byte, expired bool) int {
+func (d *TerminalReader) sendEvents(ctx context.Context, eventc chan<- Event, buf []byte, expired bool) int {
 	n, events := d.eventScanner.scanEvents(buf, expired)
-	for _, event := range events {
+	for i, event := range events {
+		if i > 0 {
+			if kp, ok := event.(KeyPressEvent); ok && len(kp.Text) == 0 {
+				// Pace bursts of non-printable key events (e.g. auto-repeating
+				// navigation keys) so frame-based renderers can present each
+				// intermediate state. Printable text is dispatched immediately
+				// to avoid slowing down typing and pasting.
+				if !d.paceEvents(ctx) {
+					break
+				}
+			}
+		}
 		eventc <- event
 	}
 	return n
+}
+
+// paceEvents waits for [EventDispatchInterval] to allow frame-based renderers
+// to present the previous event before the next one is dispatched. It returns
+// false if the context was cancelled while waiting.
+func (d *TerminalReader) paceEvents(ctx context.Context) bool {
+	timer := time.NewTimer(EventDispatchInterval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 // eventScanner scans the buffer for events and sends them to the event channel.


### PR DESCRIPTION
## Problem

When a terminal delivers a burst of key events in a single read (e.g. an auto-repeating key held down, or Ghostty coalescing writes), `TerminalReader` decodes all of them and dispatches them back-to-back. Frame-based renderers like Bubble Tea's flush at a fixed rate (60 fps), so a burst is processed within a single frame and only the **first and last** program states are ever rendered.

For a held `alt+left`/`alt+right` in [crush](<https://github.com/charmbracelet/crush>) this looks like: the cursor moves one word, then silently reaches the final position and only then shows feedback — it jumps instead of moving word-by-word. See charmbracelet/crush#3392.

## Fix

`sendEvents` now paces the dispatch of non-printable key events decoded from the same buffer, waiting [`EventDispatchInterval`](<https://github.com/charmbracelet/ultraviolet/blob/main/terminal_reader.go>) (20ms, just over one 60fps frame) between each one. That gives the renderer a full frame to present each intermediate state.

Printable text is deliberately **not** paced — typing and pasting must stay instant.

## Verification

* `go test ./...` passes (added `TestReadNonPrintableBurstIsPaced` and `TestReadPrintableBurstIsNotPaced`).
* Reproduced the original crush bug with a real Bubble Tea + `ScreenBuffer` harness: a burst of 7 `alt+left` sequences produced only the initial and final cursor positions before the fix, and all 7 intermediate positions after.