### PR TITLE
fix: clear leftover rows after inline erase

### DIFF
--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -1301,15 +1301,24 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 		s.clearBelow(newbuf, nil, newHeight-1)
 	}
 
+	// Keep the old height through an inline erase so we can still walk the
+	// cursor back to the top. Shrinking first clamps Y and we never move.
+	holdHeight := s.clear &&
+		!s.flags.Contains(tFullscreen) &&
+		curHeight > newHeight
+
 	// Resize the model before diffing so the loop below walks every row
 	// of the new screen, including rows added by a grow.
-	if curWidth != newWidth || curHeight != newHeight {
+	if !holdHeight && (curWidth != newWidth || curHeight != newHeight) {
 		s.curbuf.Resize(newWidth, newHeight)
 	}
 
 	if s.clear { //nolint:nestif
 		s.clearUpdate(newbuf)
 		s.clear = false
+		if holdHeight {
+			s.curbuf.Resize(newWidth, newHeight)
+		}
 	} else if touchedLines > 0 {
 		// On Windows, there's a bug with Windows Terminal where [ansi.DECSTBM]
 		// misbehaves and moves the cursor outside of the scrolling region. For

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -1451,6 +1451,39 @@ func TestRendererInlineShrinkClearsPartially(t *testing.T) {
 	}
 }
 
+// Same setup as the partial-clear shrink, but with Erase() in between.
+// The cursor has to walk back to the top of the old frame before we wipe.
+func TestRendererInlineEraseThenShrinkClearsFromTop(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+	r.SetRelativeCursor(true)
+	r.Resize(80, 24)
+
+	cellbuf := NewRenderBuffer(80, 3)
+	for y := range 3 {
+		cellbuf.SetCell(0, y, &Cell{Content: "a", Width: 1})
+	}
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+	buf.Reset()
+
+	r.Erase()
+	cellbuf.Resize(80, 1)
+	cellbuf.SetCell(0, 0, &Cell{Content: "b", Width: 1})
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+
+	// Up two rows from row 2, erase the rest of the screen, draw the new row.
+	expected := "\r\x1b[2A\x1b[Jb\r"
+	if output := buf.String(); output != expected {
+		t.Errorf("expected output after Erase+shrink to be %q, got: %q", expected, output)
+	}
+}
+
 // Rows added by a grow have to be diffed like any other. The model is resized
 // before the diff loop runs so the loop walks them; otherwise content drawn
 // into a new row never reaches the terminal.


### PR DESCRIPTION
Fixes #155. Same leftover as #157 after `huh.Confirm`.

I ran into this in [`deployah init`](https://github.com/deployah-dev/deployah), which prompts through [nabat](https://github.com/nabat-dev/nabat). After answering the overwrite Confirm, the project-name Input drew underneath the old question. Title and Yes/No stayed on screen.

## What goes wrong

Bubble Tea calls `Erase()` when the next frame is shorter. After #148 we resize `curbuf` before that erase, so `move()` thinks the cursor is already on the new last row and never goes up. Erase-below then fires on the old last line and the rows above survive.

## Fix

Keep the old height until after the inline erase, then resize. Grow still resizes before the diff, so the #148 paint-new-rows fix is unchanged.

This is not #145. That one is a window shrink / reflow problem, not an application-frame shrink with `Erase()`.