### PR TITLE
fix: decode legacy CSI single-param modifier encoding for cursor keys

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -486,10 +486,17 @@ func (p *EventDecoder) parseCsi(b []byte) (int, Event) {
 		}
 		id, _, _ := pa.Param(0, 1)
 		mod, _, _ := pa.Param(1, 1)
-		if paramsLen > 2 && !pa[1].HasMore() || id != 1 {
+		if paramsLen > 2 && !pa[1].HasMore() || paramsLen > 1 && id != 1 {
 			break
 		}
-		if paramsLen > 1 && id == 1 && mod != -1 {
+		if paramsLen == 1 && id > 1 {
+			// CSI <modifiers> A is the legacy single-parameter encoding
+			// of modified cursor and editing keys, where the parameter
+			// is an XTerm modifier code (1 + Shift(1) + Alt(2) +
+			// Ctrl(4)). For example, tmux emits CSI 5 D for Ctrl+Left
+			// when xterm-keys is off.
+			k.Mod |= KeyMod(id - 1)
+		} else if paramsLen > 1 && id == 1 && mod != -1 {
 			// CSI 1 ; <modifiers> A
 			k.Mod |= KeyMod(mod - 1)
 		}

--- a/key_test.go
+++ b/key_test.go
@@ -2744,3 +2744,41 @@ func TestKeyStringMore(t *testing.T) {
 		})
 	}
 }
+
+func TestLegacyCsiModifiedKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		seq  []byte
+		want Event
+	}{
+		{"ctrl+left", []byte("\x1b[5D"), KeyPressEvent{Code: KeyLeft, Mod: ModCtrl}},
+		{"ctrl+right", []byte("\x1b[5C"), KeyPressEvent{Code: KeyRight, Mod: ModCtrl}},
+		{"ctrl+up", []byte("\x1b[5A"), KeyPressEvent{Code: KeyUp, Mod: ModCtrl}},
+		{"ctrl+down", []byte("\x1b[5B"), KeyPressEvent{Code: KeyDown, Mod: ModCtrl}},
+		{"shift+left", []byte("\x1b[2D"), KeyPressEvent{Code: KeyLeft, Mod: ModShift}},
+		{"alt+right", []byte("\x1b[3C"), KeyPressEvent{Code: KeyRight, Mod: ModAlt}},
+		{"shift+ctrl+left", []byte("\x1b[6D"), KeyPressEvent{Code: KeyLeft, Mod: ModShift | ModCtrl}},
+		{"shift+ctrl+right", []byte("\x1b[6C"), KeyPressEvent{Code: KeyRight, Mod: ModShift | ModCtrl}},
+		{"ctrl+home", []byte("\x1b[5H"), KeyPressEvent{Code: KeyHome, Mod: ModCtrl}},
+		{"ctrl+end", []byte("\x1b[5F"), KeyPressEvent{Code: KeyEnd, Mod: ModCtrl}},
+
+		// Unmodified and xterm-style sequences must be unchanged.
+		{"plain left", []byte("\x1b[D"), KeyPressEvent{Code: KeyLeft}},
+		{"xterm ctrl+left", []byte("\x1b[1;5D"), KeyPressEvent{Code: KeyLeft, Mod: ModCtrl}},
+		{"xterm shift+ctrl+right", []byte("\x1b[1;6C"), KeyPressEvent{Code: KeyRight, Mod: ModShift | ModCtrl}},
+		{"plain home", []byte("\x1b[H"), KeyPressEvent{Code: KeyHome}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var p EventDecoder
+			n, e := p.Decode(test.seq)
+			if n != len(test.seq) {
+				t.Fatalf("Decode(%q): expected to consume %d bytes, got %d", test.seq, len(test.seq), n)
+			}
+			if !reflect.DeepEqual(e, test.want) {
+				t.Fatalf("Decode(%q): expected %#v, got %#v", test.seq, test.want, e)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Modified cursor/editing keys sent in the legacy single-parameter CSI encoding are silently dropped by the event decoder — no `KeyPressEvent` is emitted at all.

For example, `CSI 5 D` (Ctrl+Left) decodes to `UnknownCsiEvent`. This is the encoding **tmux emits for ctrl/shift-modified arrow keys when `xterm-keys` is off** (its historical default), and it also appears in some terminfo entries. Users of TUI apps built on ultraviolet/bubbletea v2 inside tmux get no response at all from ctrl+arrow bindings, while the same keys work outside tmux.

Real-world report: https://github.com/charmbracelet/crush/issues/3603

## Fix

In the cursor/editing-key branch of `parseCsi`, accept the legacy form where a *single* parameter carries the XTerm modifier code directly (`1 + Shift(1) + Alt(2) + Ctrl(4)`):

- `CSI 5 D` → `KeyLeft | ModCtrl`
- `CSI 2 C` → `KeyRight | ModShift`
- `CSI 6 D` → `KeyLeft | ModShift | ModCtrl`

All existing behavior is preserved: plain sequences (`CSI D`), the xterm two-parameter form (`CSI 1;5D`), and rejection rules for invalid parameter combinations are unchanged. The SS3 parser already handles the equivalent modifier form (`ESC O 5 D`), so this brings the CSI path to parity.

## Testing

- Added `TestLegacyCsiModifiedKeys`: covers all four directions plus Home/End with single-param modifiers, shift/alt/shift+ctrl variants, and regression checks that unmodified and `1;5`-style sequences decode exactly as before
- `go test ./...` passes across all packages

Verified end-to-end with a bubbletea v2 + bubbles textarea program run under tmux: before the patch, injected `\x1b[5D` produced no key event; after, it word-jumps as expected.
