### PR TITLE
fix(renderer): don't clamp cursor row in relative cursor mode

### DIFF
--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -459,7 +459,13 @@ func (s *TerminalRenderer) move(newbuf *RenderBuffer, x, y int) {
 	// }
 
 	if height > 0 {
-		if s.cur.Y > height-1 {
+		// Only clamp the remembered cursor row in fullscreen mode, where the
+		// buffer covers the whole screen. In relative mode the terminal
+		// screen extends beyond the frame buffer: after a shrink the
+		// real cursor can legitimately sit below the new frame's last row,
+		// and clamping the model here would skip the cursor-up move and leave
+		// the old frame's top lines on screen.
+		if !s.flags.Contains(tRelativeCursor) && s.cur.Y > height-1 {
 			s.cur.Y = height - 1
 		}
 		if y > height-1 {

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -1452,6 +1452,49 @@ func TestRendererInlineShrinkClearsPartially(t *testing.T) {
 	}
 }
 
+// The same shrink, but through the full-erase path an application takes when it
+// knows the frame changed shape. The erase covers from the cursor to the end of
+// the screen, so where the cursor is decides how much of the old frame it
+// reaches, and the cursor is still on the last row of the frame that just ended.
+//
+// Clamping the remembered row to the new frame's height leaves the model
+// claiming the cursor is already at the top. The move up is then computed as
+// nothing, the erase runs from the bottom of the old frame, and every row above
+// it survives into the new one.
+func TestRendererInlineShrinkErasesFromTheTop(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+	r.SetRelativeCursor(true)
+	r.Resize(80, 24)
+
+	cellbuf := NewRenderBuffer(80, 3)
+	for y := range 3 {
+		cellbuf.SetCell(0, y, &Cell{Content: "a", Width: 1})
+	}
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+	buf.Reset()
+
+	// Two rows shorter, painted from scratch rather than diffed.
+	r.Erase()
+	cellbuf.Touched = nil
+	cellbuf.Resize(80, 1)
+	cellbuf.Clear()
+	cellbuf.SetCell(0, 0, &Cell{Content: "b", Width: 1})
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+
+	// Up two rows from row 2, erase what the old frame left, draw row 0.
+	expected := "\r\x1b[2A\x1b[Jb\r"
+	if output := buf.String(); output != expected {
+		t.Errorf("expected output after shrink to be %q, got: %q", expected, output)
+	}
+}
+
 // Rows added by a grow have to be diffed like any other. The model is resized
 // before the diff loop runs so the loop walks them; otherwise content drawn
 // into a new row never reaches the terminal.


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] ~I have created a discussion that was approved by a maintainer (for new features).~

Heya, long time no see :)

I was upgrading one of [my tools](https://github.com/jon4hz/awoolt) to your v2 libraries that mainly uses bubbletea in inline mode and I think I found a rendering bug when switching between different views that have different heights.
The rendered doesn't clear the screen correctly and leaves old frames behind.

Example:
```go
package main

import (
	"fmt"
	"os"
	"strings"

	tea "charm.land/bubbletea/v2"
)

type model struct {
	n    int
	tall bool
}

func (m model) Init() tea.Cmd { return nil }

func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
	if key, ok := msg.(tea.KeyPressMsg); ok {
		switch key.String() {
		case "q", "esc", "ctrl+c":
			return m, tea.Quit
		case "space", "enter":
			m.tall, m.n = !m.tall, m.n+1
		}
	}
	return m, nil
}

func (m model) View() tea.View {
	if m.tall {
		lines := []string{fmt.Sprintf("TALL  frame #%d", m.n)}
		for i := 1; i <= 6; i++ {
			lines = append(lines, fmt.Sprintf("   line %d", i))
		}
		lines = append(lines, "space: swap  q: quit")
		return tea.NewView(strings.Join(lines, "\n")) // 8 lines
	}
	return tea.NewView(fmt.Sprintf("SHORT frame #%d  (space: swap  q: quit)", m.n)) // 1 line
}

func main() {
	tea.NewProgram(model{tall: true}).Run()
}
```