### PR TITLE
fix: carry data-bearing escape sequences, and repaint on height changes

### DIFF
--- a/internal/conformance/README.md
+++ b/internal/conformance/README.md
@@ -77,23 +77,6 @@ before any mutation starts.
 Add to it rather than pruning it. When a nightly run fails, download the
 `crashers-*` artifact and commit the new file alongside the fix.
 
-## A known gap
-
-One class of failure is not in the corpus, because it has no fix yet and the
-`test` job has to stay green: a narrow shrink followed by a grow.
-
-Shrinking the screen makes the terminal rewrap a row too wide to fit, which can
-push content onto rows that are off-screen at the time. Growing the screen
-brings those rows back, still holding it. The renderer's model never painted
-them and has no record to repair, so the residue survives every later frame.
-Forcing a full repaint on any resize would cover it, at roughly double the cost
-of `BenchmarkRenderResize`; repainting only the rows the model knows are
-drift-prone, which is what happens today, does not reach rows it never owned.
-
-The nightly run rediscovers this regularly. Programs that resize twice with no
-render in between, around content wider than the screen, are this and not a new
-bug.
-
 [libghostty]: https://github.com/mitchellh/go-libghostty
 [x/vt]: https://github.com/charmbracelet/x/tree/main/vt
 [zig]: https://ghostty.org/docs/install/build

--- a/internal/conformance/README.md
+++ b/internal/conformance/README.md
@@ -77,6 +77,18 @@ before any mutation starts.
 Add to it rather than pruning it. When a nightly run fails, download the
 `crashers-*` artifact and commit the new file alongside the fix.
 
+One kind of failure does not belong in it. x/vt drops a combining mark from the
+last cell it wrote when an erase follows, so a row the renderer paints correctly
+reads back short:
+
+	"\r" + "e\u0301"            both emulators read back "e\u0301"
+	"\r" + "e\u0301" + "\x1b[K"  ghostty reads "e\u0301", x/vt reads "e"
+
+The renderer's output is the same either way and ghostty agrees with it, so
+there is nothing here to fix on this side. charmbracelet/x#962 fixes the
+emulator; until it lands and the dependency moves, a fuzz run that finds this
+has found that bug, not a renderer bug.
+
 [libghostty]: https://github.com/mitchellh/go-libghostty
 [x/vt]: https://github.com/charmbracelet/x/tree/main/vt
 [zig]: https://ghostty.org/docs/install/build

--- a/internal/conformance/oracle_test.go
+++ b/internal/conformance/oracle_test.go
@@ -123,7 +123,16 @@ func (g *ghosttyOracle) Row(t *testing.T, y int) string {
 
 	var b strings.Builder
 	for x := range g.w {
-		b.WriteString(g.CellAt(t, x, y))
+		cell := g.CellAt(t, x, y)
+		if cell == "" {
+			// A cell that was erased reports no codepoint, while a cell
+			// someone wrote a space into reports one. They look the same on
+			// screen and mean the same thing, so read them back the same way.
+			// Otherwise a row painted by erasing compares unequal to the same
+			// row painted with spaces.
+			cell = " "
+		}
+		b.WriteString(cell)
 	}
 
 	// Empty cells read back as NUL rather than a space, so trim both.

--- a/internal/conformance/reflow_test.go
+++ b/internal/conformance/reflow_test.go
@@ -1,0 +1,64 @@
+package conformance_test
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/ultraviolet/internal/conformance"
+)
+
+// A screen that shrinks narrow enough to rewrap a row, then grows again, is the
+// case the nightly run kept finding and the corpus could not hold: the inputs
+// it minimised to were long, and what they were really exercising is short.
+//
+// Shrinking makes the terminal rewrap a row too wide to fit, which pushes
+// content onto rows that are off-screen at the time. Growing brings those rows
+// back, still holding it. The renderer never painted them, so nothing in its
+// model says they are dirty, and the residue used to survive every later frame.
+func TestReflowAcrossShrinkAndGrow(t *testing.T) {
+	const wave = "\U0001f44b\U0001f3ff" // four columns under legacy widths
+
+	wide := ""
+	for range 6 {
+		wide += wave
+	}
+
+	progs := map[string]conformance.Program{
+		// Rows wider than the screen, squeezed to a fifth of the width and
+		// then opened out past the original height.
+		"shrink then grow taller": {
+			Width: 26, Height: 2,
+			Ops: []conformance.Op{
+				{Kind: conformance.OpDrawLine, Y: 0, Text: wide},
+				{Kind: conformance.OpDrawLine, Y: 1, Text: wide},
+				{Kind: conformance.OpRender},
+				{Kind: conformance.OpResize, W: 5, H: 2},
+				{Kind: conformance.OpRender},
+				{Kind: conformance.OpResize, W: 23, H: 8},
+			},
+		},
+		// The same shape with the rows drawn out of order and a gentler
+		// shrink, which is how the fuzzer first hit it.
+		"shrink then grow, rows out of order": {
+			Width: 26, Height: 4,
+			Ops: []conformance.Op{
+				{Kind: conformance.OpDrawLine, Y: 2, Text: wide},
+				{Kind: conformance.OpDrawLine, Y: 0, Text: wide},
+				{Kind: conformance.OpDrawLine, Y: 1, Text: wide},
+				{Kind: conformance.OpRender},
+				{Kind: conformance.OpResize, W: 11, H: 2},
+				{Kind: conformance.OpRender},
+				{Kind: conformance.OpResize, W: 23, H: 8},
+			},
+		},
+	}
+
+	for name, prog := range progs {
+		t.Run(name, func(t *testing.T) {
+			for _, o := range oracles {
+				got := runIncremental(t, prog, o.mk)
+				want := runFullRepaint(t, prog, o.mk)
+				compare(t, prog, o.name, got, want)
+			}
+		})
+	}
+}

--- a/internal/conformance/testdata/fuzz/FuzzRenderer/31d50934f50a96eb
+++ b/internal/conformance/testdata/fuzz/FuzzRenderer/31d50934f50a96eb
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\"000000A0A000A0X021AX12A00")

--- a/internal/conformance/testdata/fuzz/FuzzRenderer/b658c8931146f4d4
+++ b/internal/conformance/testdata/fuzz/FuzzRenderer/b658c8931146f4d4
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0X02A0C00xA9")

--- a/styled.go
+++ b/styled.go
@@ -98,6 +98,26 @@ func (s *StyledString) Bounds() Rectangle {
 
 // printString draws a string starting at the given position. If s is nil, it
 // will build and return a slice of [Line]s instead (unwrapped, ignoring bounds).
+// passThrough reports whether a zero-width sequence should be carried in a
+// cell's content and replayed to the terminal, rather than dropped.
+//
+// The string-type sequences (APC, DCS, SOS, PM) and OSC carry data rather than
+// drive the cursor: image protocols, window titles, clipboard writes. An
+// application that puts one in its view means it to reach the terminal, and a
+// cell carrying one still advances by its own width, so the renderer's column
+// model still holds.
+//
+// Everything else is dropped, as it was before. A CSI can move the cursor or
+// erase part of the screen and an ESC Fs sequence can reset the terminal
+// outright. Replaying one from inside a cell would move the real cursor
+// somewhere the model cannot see, which is the drift a cell buffer exists to
+// keep out.
+func passThrough[T []byte | string](seq T) bool {
+	return ansi.HasApcPrefix(seq) || ansi.HasDcsPrefix(seq) ||
+		ansi.HasSosPrefix(seq) || ansi.HasPmPrefix(seq) ||
+		ansi.HasOscPrefix(seq)
+}
+
 func printString[T []byte | string](
 	s Screen,
 	m WidthMethod,
@@ -129,6 +149,7 @@ func printString[T []byte | string](
 	var link Link
 	var state byte
 	lastX, lastY := -1, -1 // last cell written, for folding in combining marks
+	var pending string     // pass-through sequences awaiting a cell to ride on
 	for len(str) > 0 {
 		seq, width, n, newState := decoder(str, state, p)
 		// The decoder's ASCII fast path doesn't check for trailing combining
@@ -148,6 +169,14 @@ func printString[T []byte | string](
 		case width > 0:
 			cell.Width = width
 			cell.Content = string(seq)
+			// Any pass-through sequences seen since the last cell belong in
+			// front of this glyph, the order they arrived in. Checked rather
+			// than concatenated unconditionally, because there are none at all
+			// on the overwhelmingly common path and the join is not free.
+			if pending != "" {
+				cell.Content = pending + cell.Content
+				pending = ""
+			}
 			cell.Style = style
 			cell.Link = link
 
@@ -232,8 +261,8 @@ func printString[T []byte | string](
 						s.SetCell(lastX, lastY, &folded)
 					}
 				}
-			default:
-				cell.Content += string(seq)
+			case passThrough(seq):
+				pending += string(seq)
 			}
 		}
 
@@ -245,6 +274,26 @@ func printString[T []byte | string](
 			// We've reached the bottom of the bounds, stop processing further
 			// lines.
 			break
+		}
+	}
+
+	// Pass-through sequences left at the end of the string have no glyph to
+	// ride in front of, so fold them into the last cell written instead. The
+	// alternative is a width-0 cell one past the content, which lands outside
+	// the bounds whenever the string filled them.
+	if pending != "" {
+		if s == nil {
+			if lastY >= 0 && lastY < len(lines) && lastX >= 0 && lastX < len(lines[lastY]) {
+				lines[lastY][lastX].Content += pending
+				pending = ""
+			}
+		} else if lastX >= 0 {
+			if prev := s.CellAt(lastX, lastY); prev != nil {
+				folded := *prev
+				folded.Content += pending
+				s.SetCell(lastX, lastY, &folded)
+				pending = ""
+			}
 		}
 	}
 

--- a/styled.go
+++ b/styled.go
@@ -101,47 +101,48 @@ func (s *StyledString) Bounds() Rectangle {
 // passThrough reports whether a zero-width sequence should be carried in a
 // cell's content and replayed to the terminal, rather than dropped.
 //
-// The string-type sequences (APC, DCS, SOS, PM) and OSC carry data rather than
-// drive the cursor: image protocols, window titles, clipboard writes. An
-// application that puts one in its view means it to reach the terminal, and a
-// cell carrying one still advances by its own width, so the renderer's column
+// The string-type sequences carry private data rather than driving the cursor:
+// APC for image protocols, DCS for device control, SOS and PM for whatever an
+// application agrees with its terminal. One means it to reach the terminal, and
+// a cell carrying one still advances by its own width, so the renderer's column
 // model still holds.
 //
-// Everything else is dropped, as it was before. A CSI can move the cursor or
-// erase part of the screen and an ESC Fs sequence can reset the terminal
-// outright. Replaying one from inside a cell would move the real cursor
-// somewhere the model cannot see, which is the drift a cell buffer exists to
-// keep out.
+// Everything else is dropped, as it was before:
+//
+//   - A CSI can move the cursor or erase part of the screen, and an ESC Fs
+//     sequence can reset the terminal outright. Replaying one from inside a
+//     cell would move the real cursor somewhere the model cannot see, which is
+//     the drift a cell buffer exists to keep out.
+//   - An OSC is dropped despite carrying data, because a cell is painted again
+//     every time it changes and on every full repaint. A window title survives
+//     that, but a clipboard write (OSC 52) or a notification (OSC 9) is not
+//     something to fire again on each resize. Hyperlinks, the one OSC a cell
+//     has a place for, are read into [Link] above.
 func passThrough[T []byte | string](seq T) bool {
 	if !ansi.HasApcPrefix(seq) && !ansi.HasDcsPrefix(seq) &&
-		!ansi.HasSosPrefix(seq) && !ansi.HasPmPrefix(seq) &&
-		!ansi.HasOscPrefix(seq) {
+		!ansi.HasSosPrefix(seq) && !ansi.HasPmPrefix(seq) {
 		return false
 	}
 	return terminated(seq)
 }
 
-// terminated reports whether a string-type sequence ended the way it should.
+// terminated reports whether a string-type sequence ended with ST.
 //
 // The parser hands back whatever it has when the input runs out, so a string
 // that stops mid-sequence still arrives here. Carrying an unterminated
 // introducer into a cell would be worse than dropping it: the terminal would
 // swallow everything painted after that cell, looking for an end that never
 // comes.
+//
+// Only the two-byte ST is accepted. The one-byte C1 form, 0x9c, is also a
+// UTF-8 continuation byte, so a sequence that ran out partway through a
+// character such as U+071C ("\u071c", encoded dc 9c) ends in a byte
+// indistinguishable from a terminator. The parser and the terminal need not
+// resolve that ambiguity the same way, and guessing wrong reintroduces exactly
+// the swallowing this guards against.
 func terminated[T []byte | string](seq T) bool {
 	n := len(seq)
-	if n == 0 {
-		return false
-	}
-	switch seq[n-1] {
-	case ansi.BEL: // an OSC may end with BEL instead
-		return true
-	case 0x9c: // C1 ST, a single byte
-		return true
-	case '\\':
-		return n >= 2 && seq[n-2] == ansi.ESC
-	}
-	return false
+	return n >= 2 && seq[n-1] == '\\' && seq[n-2] == ansi.ESC
 }
 
 func printString[T []byte | string](
@@ -175,7 +176,7 @@ func printString[T []byte | string](
 	var link Link
 	var state byte
 	lastX, lastY := -1, -1 // last cell written, for folding in combining marks
-	var pending string     // pass-through sequences awaiting a cell to ride on
+	var pending []byte     // pass-through sequences awaiting a cell to ride on
 	for len(str) > 0 {
 		seq, width, n, newState := decoder(str, state, p)
 		// The decoder's ASCII fast path doesn't check for trailing combining
@@ -197,11 +198,12 @@ func printString[T []byte | string](
 			cell.Content = string(seq)
 			// Any pass-through sequences seen since the last cell belong in
 			// front of this glyph, the order they arrived in. Checked rather
-			// than concatenated unconditionally, because there are none at all
-			// on the overwhelmingly common path and the join is not free.
-			if pending != "" {
-				cell.Content = pending + cell.Content
-				pending = ""
+			// than joined unconditionally, because there are none at all on the
+			// overwhelmingly common path and the join is not free.
+			if len(pending) > 0 {
+				pending = append(pending, cell.Content...)
+				cell.Content = string(pending)
+				pending = pending[:0]
 			}
 			cell.Style = style
 			cell.Link = link
@@ -288,7 +290,7 @@ func printString[T []byte | string](
 					}
 				}
 			case passThrough(seq):
-				pending += string(seq)
+				pending = append(pending, string(seq)...)
 			}
 		}
 
@@ -307,18 +309,16 @@ func printString[T []byte | string](
 	// ride in front of, so fold them into the last cell written instead. The
 	// alternative is a width-0 cell one past the content, which lands outside
 	// the bounds whenever the string filled them.
-	if pending != "" {
+	if len(pending) > 0 {
 		if s == nil {
 			if lastY >= 0 && lastY < len(lines) && lastX >= 0 && lastX < len(lines[lastY]) {
-				lines[lastY][lastX].Content += pending
-				pending = ""
+				lines[lastY][lastX].Content += string(pending)
 			}
 		} else if lastX >= 0 {
 			if prev := s.CellAt(lastX, lastY); prev != nil {
 				folded := *prev
-				folded.Content += pending
+				folded.Content += string(pending)
 				s.SetCell(lastX, lastY, &folded)
-				pending = ""
 			}
 		}
 	}

--- a/styled.go
+++ b/styled.go
@@ -113,9 +113,35 @@ func (s *StyledString) Bounds() Rectangle {
 // somewhere the model cannot see, which is the drift a cell buffer exists to
 // keep out.
 func passThrough[T []byte | string](seq T) bool {
-	return ansi.HasApcPrefix(seq) || ansi.HasDcsPrefix(seq) ||
-		ansi.HasSosPrefix(seq) || ansi.HasPmPrefix(seq) ||
-		ansi.HasOscPrefix(seq)
+	if !ansi.HasApcPrefix(seq) && !ansi.HasDcsPrefix(seq) &&
+		!ansi.HasSosPrefix(seq) && !ansi.HasPmPrefix(seq) &&
+		!ansi.HasOscPrefix(seq) {
+		return false
+	}
+	return terminated(seq)
+}
+
+// terminated reports whether a string-type sequence ended the way it should.
+//
+// The parser hands back whatever it has when the input runs out, so a string
+// that stops mid-sequence still arrives here. Carrying an unterminated
+// introducer into a cell would be worse than dropping it: the terminal would
+// swallow everything painted after that cell, looking for an end that never
+// comes.
+func terminated[T []byte | string](seq T) bool {
+	n := len(seq)
+	if n == 0 {
+		return false
+	}
+	switch seq[n-1] {
+	case ansi.BEL: // an OSC may end with BEL instead
+		return true
+	case 0x9c: // C1 ST, a single byte
+		return true
+	case '\\':
+		return n >= 2 && seq[n-2] == ansi.ESC
+	}
+	return false
 }
 
 func printString[T []byte | string](

--- a/styled_test.go
+++ b/styled_test.go
@@ -557,3 +557,66 @@ func TestStyledStringCombiningMarks(t *testing.T) {
 		})
 	}
 }
+
+// A string-type sequence is only carried when it actually ended. The parser
+// hands back whatever it has when the input runs out, and an unterminated
+// introducer in a cell would swallow everything painted after it, looking for
+// an end that never comes.
+func TestPassThroughTerminators(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input   string
+		carried bool
+	}{
+		"APC ends with ST":     {"\x1b_x\x1b\\a", true},
+		"APC ends with C1 ST":  {"\x1b_x\x9ca", true},
+		"C1 APC and C1 ST":     {"\x9fx\x9ca", true},
+		"OSC ends with BEL":    {"\x1b]0;t\x07a", true},
+		"OSC ends with ST":     {"\x1b]0;t\x1b\\a", true},
+		"DCS ends with ST":     {"\x1bP1$r0m\x1b\\a", true},
+		"SOS ends with ST":     {"\x1bXfoo\x1b\\a", true},
+		"PM ends with ST":      {"\x1b^bar\x1b\\a", true},
+		"APC never terminated": {"a\x1b_x", false},
+		"OSC never terminated": {"a\x1b]0;t", false},
+		"DCS never terminated": {"a\x1bP1$r0m", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ss := NewStyledString(tc.input)
+			area := ss.Bounds()
+			buf := NewScreenBuffer(area.Dx(), area.Dy())
+			ss.Draw(buf, area)
+
+			var content string
+			for x := 0; x < buf.Width(); x++ {
+				if c := buf.CellAt(x, 0); c != nil {
+					content += c.Content
+				}
+			}
+			// Every input above holds exactly one visible glyph, so anything
+			// beyond a single byte is the sequence riding along. Checked by
+			// length rather than by looking for an introducer, because a C1
+			// introducer is a lone 0x9f byte and not a rune any search would
+			// match.
+			if carried := len(content) > 1; carried != tc.carried {
+				t.Errorf("carried = %v, want %v (cells hold %q)", carried, tc.carried, content)
+			}
+		})
+	}
+}
+
+// A carried sequence must not change how wide its cell measures.
+// [lineHasDrift] works the width out from the content, so a sequence that
+// counted would have the renderer treat every line holding one as drift-prone
+// and repaint it whole.
+func TestPassThroughDoesNotAffectWidth(t *testing.T) {
+	ss := NewStyledString("\x1b_x\x1b\\abc")
+	area := ss.Bounds()
+	buf := NewScreenBuffer(area.Dx(), area.Dy())
+	ss.Draw(buf, area)
+
+	if c := buf.CellAt(0, 0); c == nil || c.Width != 1 {
+		t.Errorf("cell holding a sequence has width %v, want 1", c)
+	}
+	if lineHasDrift(ansi.WcWidth, buf.Line(0)) {
+		t.Error("a line holding a pass-through sequence was flagged drift-prone")
+	}
+}

--- a/styled_test.go
+++ b/styled_test.go
@@ -558,26 +558,37 @@ func TestStyledStringCombiningMarks(t *testing.T) {
 	}
 }
 
-// A string-type sequence is only carried when it actually ended. The parser
-// hands back whatever it has when the input runs out, and an unterminated
-// introducer in a cell would swallow everything painted after it, looking for
-// an end that never comes.
+// A string-type sequence is only carried when it actually ended, and only when
+// it is one of the kinds a cell has any business replaying.
 func TestPassThroughTerminators(t *testing.T) {
 	for name, tc := range map[string]struct {
 		input   string
 		carried bool
 	}{
-		"APC ends with ST":     {"\x1b_x\x1b\\a", true},
-		"APC ends with C1 ST":  {"\x1b_x\x9ca", true},
-		"C1 APC and C1 ST":     {"\x9fx\x9ca", true},
-		"OSC ends with BEL":    {"\x1b]0;t\x07a", true},
-		"OSC ends with ST":     {"\x1b]0;t\x1b\\a", true},
-		"DCS ends with ST":     {"\x1bP1$r0m\x1b\\a", true},
-		"SOS ends with ST":     {"\x1bXfoo\x1b\\a", true},
-		"PM ends with ST":      {"\x1b^bar\x1b\\a", true},
+		"APC ends with ST": {"\x1b_x\x1b\\a", true},
+		"DCS ends with ST": {"\x1bP1$r0m\x1b\\a", true},
+		"SOS ends with ST": {"\x1bXfoo\x1b\\a", true},
+		"PM ends with ST":  {"\x1b^bar\x1b\\a", true},
+
+		// The parser returns what it has when the input runs out. An
+		// unterminated introducer in a cell would have the terminal swallow
+		// everything painted after it.
 		"APC never terminated": {"a\x1b_x", false},
 		"OSC never terminated": {"a\x1b]0;t", false},
 		"DCS never terminated": {"a\x1bP1$r0m", false},
+
+		// 0x9c is a UTF-8 continuation byte as well as C1 ST, so a sequence
+		// that ran out partway through a character can end in a byte that
+		// looks like a terminator. U+071C encodes as dc 9c.
+		"APC cut off mid-character": {"a\x1b_x\u071c", false},
+		"OSC cut off mid-character": {"a\x1b]0;\u071c", false},
+		"APC ends with C1 ST":       {"\x1b_x\x9ca", false},
+
+		// An OSC carries data but a cell is painted again on every repaint. A
+		// title survives that; a clipboard write or a notification should not
+		// fire again on each resize.
+		"OSC ends with BEL": {"\x1b]0;t\x07a", false},
+		"OSC ends with ST":  {"\x1b]0;t\x1b\\a", false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ss := NewStyledString(tc.input)
@@ -591,12 +602,9 @@ func TestPassThroughTerminators(t *testing.T) {
 					content += c.Content
 				}
 			}
-			// Every input above holds exactly one visible glyph, so anything
-			// beyond a single byte is the sequence riding along. Checked by
-			// length rather than by looking for an introducer, because a C1
-			// introducer is a lone 0x9f byte and not a rune any search would
-			// match.
-			if carried := len(content) > 1; carried != tc.carried {
+			// Every input above introduces its sequence with ESC, so an ESC
+			// surviving into the cells is the sequence riding along.
+			if carried := strings.ContainsRune(content, ansi.ESC); carried != tc.carried {
 				t.Errorf("carried = %v, want %v (cells hold %q)", carried, tc.carried, content)
 			}
 		})

--- a/styled_test.go
+++ b/styled_test.go
@@ -377,6 +377,59 @@ func TestStyledString(t *testing.T) {
 				},
 			},
 		},
+		{
+			// A sequence that carries data rather than driving the cursor
+			// rides in the content of the cell that follows it, so it reaches
+			// the terminal when the cell is painted. See #95.
+			name:           "APC sequence rides the next cell",
+			input:          "\x1b_foo\x1b\\bar",
+			expectedWidth:  3,
+			expectedHeight: 1,
+			expected: &Buffer{
+				Lines: []Line{
+					{
+						newWcCell("\x1b_foo\x1b\\b", nil, nil),
+						newWcCell("a", nil, nil),
+						newWcCell("r", nil, nil),
+					},
+				},
+			},
+		},
+		{
+			// At the end of the string there is no following cell, so it folds
+			// into the last one. A width-0 cell one past the content would sit
+			// outside the bounds whenever the string filled them.
+			name:           "trailing APC folds into the last cell",
+			input:          "bar\x1b_foo\x1b\\",
+			expectedWidth:  3,
+			expectedHeight: 1,
+			expected: &Buffer{
+				Lines: []Line{
+					{
+						newWcCell("b", nil, nil),
+						newWcCell("a", nil, nil),
+						newWcCell("r\x1b_foo\x1b\\", nil, nil),
+					},
+				},
+			},
+		},
+		{
+			// Cursor movement is not carried. Replaying it from inside a cell
+			// would move the real cursor somewhere the renderer's model cannot
+			// see, so it stays dropped.
+			name:           "cursor movement is not carried",
+			input:          "a\x1b[5Cb",
+			expectedWidth:  2,
+			expectedHeight: 1,
+			expected: &Buffer{
+				Lines: []Line{
+					{
+						newWcCell("a", nil, nil),
+						newWcCell("b", nil, nil),
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range cases {

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -834,7 +834,17 @@ func lineHasDrift(m ansi.Method, line Line) bool {
 		if c == nil || c.Width == 0 || len(c.Content) == 0 {
 			continue
 		}
-		if c.Width > 1 || m.StringWidth(c.Content) != ansi.StringWidth(c.Content) {
+		if c.Width > 1 {
+			return true
+		}
+		// One printable ASCII byte is one column under every width model, so
+		// it can never be a cell the models disagree about. Worth saying out
+		// loud because working the width out means segmenting the content,
+		// and this runs for every cell of every line the renderer diffs.
+		if len(c.Content) == 1 && c.Content[0] >= 0x20 && c.Content[0] < 0x7f {
+			continue
+		}
+		if m.StringWidth(c.Content) != ansi.StringWidth(c.Content) {
 			return true
 		}
 	}

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -1386,7 +1386,12 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 		// fullscreen, where the renderer owns every cell it is about to
 		// clear. Inline mode shares the screen with whatever came before,
 		// so it uses the narrower partial clear below instead.
-		if s.flags.Contains(tFullscreen) && (newWidth < curWidth || newHeight < curHeight) {
+		// A shrink makes the terminal reflow. A height grow is no safer: the
+		// terminal fills the rows it gains from its scrollback, and an earlier
+		// shrink may have rewrapped a row too wide to fit into exactly that
+		// space. Those lines come back at the top and push the screen down, so
+		// no row keeps its meaning and there is nothing to diff against.
+		if s.flags.Contains(tFullscreen) && (newWidth < curWidth || newHeight != curHeight) {
 			s.clear = true
 		}
 	}

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -1455,6 +1455,10 @@ func TestRendererInlineShrinkClearsPartially(t *testing.T) {
 // Rows added by a grow have to be diffed like any other. The model is resized
 // before the diff loop runs so the loop walks them; otherwise content drawn
 // into a new row never reaches the terminal.
+//
+// The grow repaints the screen rather than diffing it. The terminal fills rows
+// it gains from its own scrollback, and those lines arrive at the top and push
+// the rest down, so no row keeps its meaning across the resize.
 func TestRendererGrowPaintsNewRows(t *testing.T) {
 	var buf bytes.Buffer
 	r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
@@ -1477,7 +1481,7 @@ func TestRendererGrowPaintsNewRows(t *testing.T) {
 		t.Fatalf("failed to flush renderer: %v", err)
 	}
 
-	expected := "\x1b[6;1HZ"
+	expected := "\x1b[H\x1b[2JA\r\x1b[6dZ"
 	if output := buf.String(); output != expected {
 		t.Errorf("expected output after grow to be %q, got: %q", expected, output)
 	}

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -1555,3 +1555,85 @@ func TestRendererNoWrapOnDriftLine(t *testing.T) {
 		t.Errorf("plain row should not touch autowrap, got: %q", narrow)
 	}
 }
+
+// The repaint a height change forces belongs to fullscreen mode and to actual
+// changes. Inline frames are shorter than the terminal by design, and a render
+// that resizes nothing has nothing to distrust.
+func TestHeightRepaintScope(t *testing.T) {
+	render := func(r *TerminalRenderer, w, h int, mark string) {
+		cb := NewRenderBuffer(w, h)
+		cb.SetCell(0, 0, &Cell{Content: mark, Width: 1})
+		r.Render(cb)
+		if err := r.Flush(); err != nil {
+			t.Fatalf("Flush: %v", err)
+		}
+	}
+
+	t.Run("inline mode leaves the height alone", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+		r.SetRelativeCursor(true)
+		render(r, 10, 2, "a")
+		buf.Reset()
+		render(r, 10, 5, "a")
+		if strings.Contains(buf.String(), ansi.EraseEntireScreen) {
+			t.Errorf("inline mode repainted on a height change: %q", buf.String())
+		}
+	})
+
+	t.Run("a steady size does not repaint", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+		r.SetFullscreen(true)
+		render(r, 10, 3, "a")
+		buf.Reset()
+		render(r, 10, 3, "b")
+		if strings.Contains(buf.String(), ansi.EraseEntireScreen) {
+			t.Errorf("repainted without a resize: %q", buf.String())
+		}
+	})
+
+	t.Run("degenerate sizes do not panic", func(t *testing.T) {
+		for _, size := range [][2]int{{0, 0}, {10, 0}, {0, 5}, {1, 1}} {
+			var buf bytes.Buffer
+			r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+			r.SetFullscreen(true)
+			render(r, 10, 3, "a")
+			r.Resize(size[0], size[1])
+			r.Render(NewRenderBuffer(size[0], size[1]))
+			if err := r.Flush(); err != nil {
+				t.Fatalf("size %v: Flush: %v", size, err)
+			}
+		}
+	})
+}
+
+// A carried sequence has to reach the terminal, and only when its cell changes.
+// Re-sending it every frame would have an image protocol retransmit the image
+// at the frame rate.
+func TestPassThroughSequenceReachesTerminalOnce(t *testing.T) {
+	const apc = "\x1b_Ga=T\x1b\\"
+
+	var buf bytes.Buffer
+	r := NewTerminalRenderer(&buf, []string{"TERM=xterm-256color"})
+	r.SetFullscreen(true)
+
+	scr := NewScreenBuffer(10, 2)
+	NewStyledString(apc+"hi").Draw(scr, Rect(0, 0, 10, 1))
+	r.Render(scr.RenderBuffer)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if n := strings.Count(buf.String(), apc); n != 1 {
+		t.Errorf("first render sent the sequence %d times, want 1: %q", n, buf.String())
+	}
+
+	buf.Reset()
+	r.Render(scr.RenderBuffer)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if n := strings.Count(buf.String(), apc); n != 0 {
+		t.Errorf("an unchanged render re-sent the sequence %d times: %q", n, buf.String())
+	}
+}

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -1637,3 +1637,43 @@ func TestPassThroughSequenceReachesTerminalOnce(t *testing.T) {
 		t.Errorf("an unchanged render re-sent the sequence %d times: %q", n, buf.String())
 	}
 }
+
+// The ASCII short-circuit in lineHasDrift must never change its answer.
+// Compare against the unoptimised definition over everything the conformance
+// fuzzer can draw, plus every single byte.
+func TestDriftShortCircuitAgreesWithFullCheck(t *testing.T) {
+	full := func(m ansi.Method, c *Cell) bool {
+		return c.Width > 1 || m.StringWidth(c.Content) != ansi.StringWidth(c.Content)
+	}
+
+	var contents []string
+	for b := 0; b < 256; b++ {
+		contents = append(contents, string([]byte{byte(b)}))
+	}
+	contents = append(contents,
+		"a", "\u4e16", "\uac00", "\U0001fae0", "e\u0301", "n\u0303",
+		"\u2639\ufe0e", "\u2639\ufe0f", "\u2764\ufe0f", "\u2708\ufe0f",
+		"\U0001f469\u200d\U0001f4bb", "\U0001f426\u200d\U0001f525",
+		"\U0001f44d\U0001f3fd", "\U0001f44b\U0001f3ff",
+		"\u26d3\ufe0f\u200d\U0001f4a5", "\U0001f1fa", "\U0001f1fa\U0001f1f8",
+		"\U0001f1ef\U0001f1f5", "1\ufe0f\u20e3", "", " ", "\x1b_x\x1b\\a",
+	)
+
+	for _, m := range []ansi.Method{ansi.WcWidth, ansi.GraphemeWidth} {
+		for _, content := range contents {
+			for _, w := range []int{0, 1, 2} {
+				c := &Cell{Content: content, Width: w}
+				line := Line{*c}
+				got := lineHasDrift(m, line)
+				want := false
+				if c.Width != 0 && len(c.Content) != 0 {
+					want = full(m, c)
+				}
+				if got != want {
+					t.Errorf("method=%v content=%q width=%d: short-circuit says %v, full check says %v",
+						m, content, w, got, want)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two fixes found by the nightly conformance fuzzer and issue #95, plus the
results of an adversarial pass over both.

## Escape sequences reaching the screen (#95)

`printString` accumulated an unhandled sequence into the pending cell and then
overwrote it with the next glyph, so it never reached the screen. An application
passing an APC sequence through its view (an image protocol) lost it silently.

Both #95 and #151 proposed carrying *everything* through. That is not safe: a
CSI can move the cursor or erase the screen and `ESC c` resets the terminal
outright, and replaying one from inside a cell puts the real cursor somewhere
the renderer's column model cannot see.

So only the string-type sequences that carry private data are carried: **APC,
DCS, SOS, PM**, and only when they actually terminated with `ESC \`.

Deliberately excluded:

- **CSI, ESC Fs, control characters** — they drive the cursor or the screen.
- **Unterminated sequences.** The parser returns what it has when input runs
  out; an unterminated introducer in a cell makes the terminal swallow
  everything painted after it.
- **The one-byte C1 ST (`0x9c`).** It is also a UTF-8 continuation byte, so a
  sequence cut off partway through a character such as U+071C (`dc 9c`) ends in
  a byte indistinguishable from a terminator. The parser and the terminal need
  not resolve that the same way.
- **OSC.** It bears data, but a cell is painted again on every change and every
  full repaint, so a carried OSC 52 fires the clipboard on each resize. A title
  survives that; a clipboard write or notification should not. Hyperlinks, the
  one OSC a cell has a place for, are already read into `Link`.

A sequence at the end of the string folds into the last cell written, the way a
trailing combining mark already did — the second half of #95.

### Known limits

- A sequence that is the **entire** view, or that falls past the last visible
  column or at a truncation point, is still dropped: it has no glyph to ride on
  and a width-0 cell is never painted. #95 is not fixed for a view that is only
  a sequence.
- The payload of a carried APC/DCS is opaque, so a **C1 CSI (`0x9b`) inside one
  survives**. Under `tmux` with `allow-passthrough on`, tmux strips the wrapper
  and forwards it. "A CSI cannot reach the terminal from a cell" holds directly,
  but not through a multiplexer.

## Repainting on a height change

Shrinking makes the terminal rewrap a row too wide to fit, pushing content onto
rows that are off-screen at the time. Growing brings those lines back **at the
top**, pushing the screen down:

```
after render at 5x2 : ["" ""]              screen genuinely blank
after resize 23x8   : ["👋🏿👋🏿#" "" ...]   content back at row 0
```

So erasing only the rows a grow adds does not work; the content arrives above
them. No row keeps its meaning across the resize, so the frame is repainted.

### Cost

```
RenderFrame-10    9.335µ ± 1%  →  6.415µ ± 1%   -31.29% (p=0.000 n=18)
RenderResize-10   164.7µ ± 3%  →  212.4µ ± 1%   +29.01% (p=0.000 n=18)
```

A grow now costs what a shrink already cost; that benchmark's own comment says
it exercises "the forced clear on shrink", and it was already paying this on two
of four iterations.

Most of that is paid for elsewhere. `lineHasDrift` was the largest single cost
in a resize profile — 31% cumulative, almost all of it grapheme segmentation —
because it compared two width models on every cell of every line diffed. A
single printable ASCII byte is one column under every model, so it now
short-circuits, which is what takes the resize cost from +97% to +29% and makes
the ordinary frame path 31% faster than before.
`TestDriftShortCircuitAgreesWithFullCheck` checks the shortcut against the full
definition over all 256 single bytes and every cluster in the fuzz alphabet.

`printString` pays +1.5 to +3.7% for one string-empty check per cell.

## Adversarial pass

An audit of the above found and fixed, in this branch:

- the `0x9c` terminator hole described above;
- `pending += string(seq)` being quadratic in the number of sequences —
  2.2MB of sequences took 2.8s, now 12ms;
- the OSC replay hazard, by dropping OSC.

Confirmed sound: carried sequences do not change cell width or trip
`lineHasDrift`; they reach the terminal once and are not re-sent on an unchanged
frame; the height repaint stays out of inline mode and out of renders that
resize nothing; degenerate sizes do not panic.

## Testing

`TestReflowAcrossShrinkAndGrow` covers the resize shape and fails without the
fix. `TestPassThroughTerminators` covers every terminator and exclusion above.
Full conformance corpus passes against both reference emulators.
