### PR TITLE
chore(conformance): pick up the x/vt combining-mark fix

### DIFF
--- a/internal/conformance/README.md
+++ b/internal/conformance/README.md
@@ -77,18 +77,6 @@ before any mutation starts.
 Add to it rather than pruning it. When a nightly run fails, download the
 `crashers-*` artifact and commit the new file alongside the fix.
 
-One kind of failure does not belong in it. x/vt drops a combining mark from the
-last cell it wrote when an erase follows, so a row the renderer paints correctly
-reads back short:
-
-	"\r" + "e\u0301"            both emulators read back "e\u0301"
-	"\r" + "e\u0301" + "\x1b[K"  ghostty reads "e\u0301", x/vt reads "e"
-
-The renderer's output is the same either way and ghostty agrees with it, so
-there is nothing here to fix on this side. charmbracelet/x#962 fixes the
-emulator; until it lands and the dependency moves, a fuzz run that finds this
-has found that bug, not a renderer bug.
-
 [libghostty]: https://github.com/mitchellh/go-libghostty
 [x/vt]: https://github.com/charmbracelet/x/tree/main/vt
 [zig]: https://ghostty.org/docs/install/build

--- a/internal/conformance/go.mod
+++ b/internal/conformance/go.mod
@@ -7,7 +7,7 @@ replace github.com/charmbracelet/ultraviolet => ../..
 require (
 	github.com/charmbracelet/ultraviolet v0.0.0-20260303162955-0b88c25f3fff
 	github.com/charmbracelet/x/ansi v0.11.8
-	github.com/charmbracelet/x/vt v0.0.0-20260727090823-41c9e6be3365
+	github.com/charmbracelet/x/vt v0.0.0-20260901172002-a5dee49b2863
 	go.mitchellh.com/libghostty v0.0.0-20260727203050-ef0f8ce3daa7
 )
 

--- a/internal/conformance/go.sum
+++ b/internal/conformance/go.sum
@@ -8,8 +8,8 @@ github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSg
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
-github.com/charmbracelet/x/vt v0.0.0-20260727090823-41c9e6be3365 h1:cc3fy2OvA3du4qD3wgAzMOM587VCBh8T8pXGkTn18F4=
-github.com/charmbracelet/x/vt v0.0.0-20260727090823-41c9e6be3365/go.mod h1:u1LOIABor9JqY54oZdktK3TCRrgzP6tzHrDYx1nd3wY=
+github.com/charmbracelet/x/vt v0.0.0-20260901172002-a5dee49b2863 h1:bWWkhlh6dE9xp9Aiu7GFiYg7YDoo7iQMWN+SQxyaFfo=
+github.com/charmbracelet/x/vt v0.0.0-20260901172002-a5dee49b2863/go.mod h1:u1LOIABor9JqY54oZdktK3TCRrgzP6tzHrDYx1nd3wY=
 github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2/jYn2GuM=
 github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=

--- a/internal/conformance/testdata/fuzz/FuzzRenderer/03c1c2969136ac42
+++ b/internal/conformance/testdata/fuzz/FuzzRenderer/03c1c2969136ac42
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("000A\x00000AA0200*00")


### PR DESCRIPTION
charmbracelet/x#962 is merged, so `vt` no longer drops a combining mark from the
cell it last wrote when an erase follows it.

Three separate inputs the nightly run found were all that one defect wearing
different shapes — a mark followed by `EL`, a resize with repeated `Redraw`, and
a resize redrawing over clusters. Each one cost the run its `FuzzRenderer`
budget. The one I kept the bytes for is now in the corpus, and the README note
telling people to leave that class out comes back off.

Verified: the previously vt-only failure passes, and the whole corpus passes,
against both reference emulators.