### PR TITLE
fix(styled): let Lines parse unbounded content

### DIFF
--- a/styled.go
+++ b/styled.go
@@ -298,7 +298,7 @@ func printString[T []byte | string](
 		state = newState
 		str = str[n:]
 
-		if y >= bounds.Max.Y {
+		if s != nil && y >= bounds.Max.Y {
 			// We've reached the bottom of the bounds, stop processing further
 			// lines.
 			break

--- a/styled_test.go
+++ b/styled_test.go
@@ -485,7 +485,7 @@ func TestStyledStringEmptyLines(t *testing.T) {
 	}
 }
 
-func TestStyledStringLines(t *testing.T) {
+func TestStyledStringLinesUnboundedContent(t *testing.T) {
 	const destination = "https://example.com"
 	input := "\x1b[31mab\x1b[0m\n" + ansi.SetHyperlink(destination, "") + "界" + ansi.ResetHyperlink()
 	lines := NewStyledString(input).Lines(ansi.GraphemeWidth)

--- a/styled_test.go
+++ b/styled_test.go
@@ -485,6 +485,19 @@ func TestStyledStringEmptyLines(t *testing.T) {
 	}
 }
 
+func TestStyledStringLines(t *testing.T) {
+	const destination = "https://example.com"
+	input := "\x1b[31mab\x1b[0m\n" + ansi.SetHyperlink(destination, "") + "界" + ansi.ResetHyperlink()
+	lines := NewStyledString(input).Lines(ansi.GraphemeWidth)
+
+	if got := Lines(lines).String(); got != "ab\n界" {
+		t.Fatalf("Lines().String() = %q, want %q", got, "ab\n界")
+	}
+	if cell := lines[1][0]; cell.Width != 2 || cell.Link.URL != destination {
+		t.Fatalf("linked cell = %#v, want width 2 and link %q", cell, destination)
+	}
+}
+
 func newWcCell(s string, style *Style, link *Link) Cell {
 	c := NewCell(ansi.WcWidth, s)
 	if style != nil {


### PR DESCRIPTION
Fixes #169.

`StyledString.Lines` intentionally calls `printString` without a screen or bounds, but the screen bounds exit currently stops that path after its first decoded token. Apply the exit only when drawing to a screen.

The focused regression test covers leading ANSI style state, multiple cells and lines, grapheme width, and OSC-8 link metadata.

#134 previously identified the same root cause; this updates the minimal fix and test against current `main`.

Tests: `go test ./...`, `golangci-lint run`