### PR TITLE
fix(styled): allow semicolons in hyperlink URLs

### DIFF
--- a/styled.go
+++ b/styled.go
@@ -440,7 +440,7 @@ func ReadStyle(params ansi.Params, pen *Style) {
 
 // ReadLink reads a hyperlink escape sequence from a data buffer into link.
 func ReadLink(p []byte, link *Link) {
-	params := bytes.Split(p, []byte{';'})
+	params := bytes.SplitN(p, []byte{';'}, 3)
 	if len(params) != 3 {
 		return
 	}

--- a/styled.go
+++ b/styled.go
@@ -440,6 +440,8 @@ func ReadStyle(params ansi.Params, pen *Style) {
 
 // ReadLink reads a hyperlink escape sequence from a data buffer into link.
 func ReadLink(p []byte, link *Link) {
+	// OSC 8 sequences have this structure `OSC 8 ; params ; URI ST`.
+	// Only the first two semicolons are delimiters, semicolons that follow after are part of the URI.
 	params := bytes.SplitN(p, []byte{';'}, 3)
 	if len(params) != 3 {
 		return

--- a/styled_test.go
+++ b/styled_test.go
@@ -509,6 +509,15 @@ func newWcCell(s string, style *Style, link *Link) Cell {
 	return *c
 }
 
+func TestReadLinkAllowsSemicolonsInURL(t *testing.T) {
+	var link Link
+	ReadLink([]byte("8;id=123;Other;Guide.md"), &link)
+
+	if link.Params != "id=123" || link.URL != "Other;Guide.md" {
+		t.Fatalf("ReadLink() = %#v, want params %q and URL %q", link, "id=123", "Other;Guide.md")
+	}
+}
+
 // ASCII-heavy line: the common case. Guards the printString re-decode
 // pre-filter (str[1] >= 0xc0) from regressing plain-text draws.
 func BenchmarkPrintStringASCII(b *testing.B) {


### PR DESCRIPTION
fixes #171 

Split OSC 8 data only at its two structural delimiters so valid URLs containing semicolons remain intact.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
