### PR TITLE
fix(styled): Handle long links

### DIFF
--- a/styled.go
+++ b/styled.go
@@ -145,6 +145,32 @@ func terminated[T []byte | string](seq T) bool {
 	return n >= 2 && seq[n-1] == '\\' && seq[n-2] == ansi.ESC
 }
 
+func oscPayload[T []byte | string](seq T) (T, bool) {
+	var zero T
+	if !ansi.HasOscPrefix(seq) {
+		return zero, false
+	}
+
+	start := 2
+	if seq[0] == ansi.OSC {
+		start = 1
+	}
+	if len(seq) <= start {
+		return zero, false
+	}
+
+	end := len(seq)
+	switch {
+	case seq[end-1] == ansi.BEL:
+		end--
+	case terminated(seq):
+		end -= 2
+	default:
+		return zero, false
+	}
+	return seq[start:end], true
+}
+
 func printString[T []byte | string](
 	s Screen,
 	m WidthMethod,
@@ -153,9 +179,6 @@ func printString[T []byte | string](
 	truncate bool, tail string,
 ) (lines []Line) {
 	p := ansi.GetParser()
-	if len(str) > 4<<10 {
-		p.SetDataSize(len(str))
-	}
 	defer ansi.PutParser(p)
 
 	var tailc Cell
@@ -255,9 +278,11 @@ func printString[T []byte | string](
 			case ansi.HasCsiPrefix(seq) && p.Command() == 'm':
 				// SGR - Select Graphic Rendition
 				ReadStyle(p.Params(), &style)
-			case ansi.HasOscPrefix(seq) && p.Command() == 8 && (seq[len(seq)-1] == ansi.BEL || terminated(seq)):
+			case ansi.HasOscPrefix(seq) && p.Command() == 8:
 				// Hyperlinks
-				ReadLink(p.Data(), &link)
+				if data, ok := oscPayload(seq); ok {
+					ReadLink([]byte(data), &link)
+				}
 			case ansi.Equal(seq, T("\n")):
 				if s == nil {
 					// When building lines, we need to ensure empty lines are represented.

--- a/styled.go
+++ b/styled.go
@@ -161,9 +161,9 @@ func oscPayload[T []byte | string](seq T) (T, bool) {
 
 	end := len(seq)
 	switch {
-	case seq[end-1] == ansi.BEL || seq[end-1] == ansi.ST:
+	case seq[end-1] == ansi.BEL:
 		end--
-	case end-start >= 2 && seq[end-2] == ansi.ESC && ansi.HasStPrefix(seq[end-2:]):
+	case terminated(seq):
 		end -= 2
 	default:
 		return empty, false

--- a/styled.go
+++ b/styled.go
@@ -145,6 +145,9 @@ func terminated[T []byte | string](seq T) bool {
 	return n >= 2 && seq[n-1] == '\\' && seq[n-2] == ansi.ESC
 }
 
+// oscPayload extracts data from a terminated OSC sequence. DecodeSequence
+// returns the complete sequence even when the pooled parser's 4 KiB data
+// buffer truncates Parser.Data, so using seq avoids resizing pooled buffers.
 func oscPayload[T []byte | string](seq T) (T, bool) {
 	var zero T
 	if !ansi.HasOscPrefix(seq) {

--- a/styled.go
+++ b/styled.go
@@ -155,9 +155,6 @@ func oscPayload[T []byte | string](seq T) (T, bool) {
 	if seq[0] == ansi.OSC {
 		start = 1
 	}
-	if len(seq) <= start {
-		return zero, false
-	}
 
 	end := len(seq)
 	switch {

--- a/styled.go
+++ b/styled.go
@@ -145,32 +145,6 @@ func terminated[T []byte | string](seq T) bool {
 	return n >= 2 && seq[n-1] == '\\' && seq[n-2] == ansi.ESC
 }
 
-func oscPayload[T []byte | string](seq T) (T, bool) {
-	var empty T
-	if !ansi.HasOscPrefix(seq) {
-		return empty, false
-	}
-
-	start := 2
-	if seq[0] == ansi.OSC {
-		start = 1
-	}
-	if len(seq) == start {
-		return empty, false
-	}
-
-	end := len(seq)
-	switch {
-	case seq[end-1] == ansi.BEL:
-		end--
-	case terminated(seq):
-		end -= 2
-	default:
-		return empty, false
-	}
-	return seq[start:end], true
-}
-
 func printString[T []byte | string](
 	s Screen,
 	m WidthMethod,
@@ -179,6 +153,9 @@ func printString[T []byte | string](
 	truncate bool, tail string,
 ) (lines []Line) {
 	p := ansi.GetParser()
+	if len(str) > 4<<10 {
+		p.SetDataSize(len(str))
+	}
 	defer ansi.PutParser(p)
 
 	var tailc Cell
@@ -278,11 +255,9 @@ func printString[T []byte | string](
 			case ansi.HasCsiPrefix(seq) && p.Command() == 'm':
 				// SGR - Select Graphic Rendition
 				ReadStyle(p.Params(), &style)
-			case ansi.HasOscPrefix(seq) && p.Command() == 8:
+			case ansi.HasOscPrefix(seq) && p.Command() == 8 && (seq[len(seq)-1] == ansi.BEL || terminated(seq)):
 				// Hyperlinks
-				if data, ok := oscPayload(seq); ok {
-					ReadLink([]byte(data), &link)
-				}
+				ReadLink(p.Data(), &link)
 			case ansi.Equal(seq, T("\n")):
 				if s == nil {
 					// When building lines, we need to ensure empty lines are represented.

--- a/styled.go
+++ b/styled.go
@@ -145,6 +145,32 @@ func terminated[T []byte | string](seq T) bool {
 	return n >= 2 && seq[n-1] == '\\' && seq[n-2] == ansi.ESC
 }
 
+func oscPayload[T []byte | string](seq T) (T, bool) {
+	var empty T
+	if !ansi.HasOscPrefix(seq) {
+		return empty, false
+	}
+
+	start := 2
+	if seq[0] == ansi.OSC {
+		start = 1
+	}
+	if len(seq) == start {
+		return empty, false
+	}
+
+	end := len(seq)
+	switch {
+	case seq[end-1] == ansi.BEL || seq[end-1] == ansi.ST:
+		end--
+	case end-start >= 2 && seq[end-2] == ansi.ESC && ansi.HasStPrefix(seq[end-2:]):
+		end -= 2
+	default:
+		return empty, false
+	}
+	return seq[start:end], true
+}
+
 func printString[T []byte | string](
 	s Screen,
 	m WidthMethod,
@@ -254,9 +280,9 @@ func printString[T []byte | string](
 				ReadStyle(p.Params(), &style)
 			case ansi.HasOscPrefix(seq) && p.Command() == 8:
 				// Hyperlinks
-				data := strings.TrimPrefix(strings.TrimPrefix(string(seq), "\x1b]"), "\x9d")
-				data = strings.TrimSuffix(strings.TrimSuffix(strings.TrimSuffix(data, "\a"), "\x9c"), "\x1b\\")
-				ReadLink([]byte(data), &link)
+				if data, ok := oscPayload(seq); ok {
+					ReadLink([]byte(data), &link)
+				}
 			case ansi.Equal(seq, T("\n")):
 				if s == nil {
 					// When building lines, we need to ensure empty lines are represented.

--- a/styled.go
+++ b/styled.go
@@ -254,7 +254,9 @@ func printString[T []byte | string](
 				ReadStyle(p.Params(), &style)
 			case ansi.HasOscPrefix(seq) && p.Command() == 8:
 				// Hyperlinks
-				ReadLink(p.Data(), &link)
+				data := strings.TrimPrefix(strings.TrimPrefix(string(seq), "\x1b]"), "\x9d")
+				data = strings.TrimSuffix(strings.TrimSuffix(strings.TrimSuffix(data, "\a"), "\x9c"), "\x1b\\")
+				ReadLink([]byte(data), &link)
 			case ansi.Equal(seq, T("\n")):
 				if s == nil {
 					// When building lines, we need to ensure empty lines are represented.

--- a/styled_test.go
+++ b/styled_test.go
@@ -513,6 +513,38 @@ func TestStyledStringLongHyperlink(t *testing.T) {
 	}
 }
 
+func TestOscPayload(t *testing.T) {
+	const payload = "8;;https://example.com"
+	bel := string([]byte{ansi.BEL})
+	osc := string([]byte{ansi.OSC})
+	st := string([]byte{ansi.ST})
+	tests := []struct {
+		name string
+		seq  string
+		want string
+		ok   bool
+	}{
+		{"7-bit OSC with BEL", "\x1b]" + payload + bel, payload, true},
+		{"7-bit OSC with ST", "\x1b]" + payload + "\x1b\\", payload, true},
+		{"C1 OSC with BEL", osc + payload + bel, payload, true},
+		{"C1 OSC with ST", osc + payload + "\x1b\\", payload, true},
+		{"empty payload", "\x1b]" + bel, "", true},
+		{"not OSC", payload + bel, "", false},
+		{"bare introducer", "\x1b]", "", false},
+		{"unterminated", "\x1b]" + payload, "", false},
+		{"C1 ST", "\x1b]" + payload + st, "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := oscPayload(tc.seq)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("oscPayload(%q) = (%q, %v), want (%q, %v)", tc.seq, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
 func TestStyledStringHyperlinkTermination(t *testing.T) {
 	const destination = "https://example.com"
 	linked := Link{URL: destination}

--- a/styled_test.go
+++ b/styled_test.go
@@ -501,8 +501,46 @@ func TestStyledStringLinesUnboundedContent(t *testing.T) {
 func TestStyledStringLongHyperlink(t *testing.T) {
 	const parserDataLimit = 4 << 10
 	destination := strings.Repeat("a", parserDataLimit+1)
-	if got := NewStyledString(ansi.SetHyperlink(destination) + "x").Lines(ansi.GraphemeWidth)[0][0].Link.URL; got != destination {
+	ss := NewStyledString(ansi.SetHyperlink(destination) + "x")
+	if got := ss.Lines(ansi.GraphemeWidth)[0][0].Link.URL; got != destination {
 		t.Errorf("Lines hyperlink length = %d, want %d", len(got), len(destination))
+	}
+
+	buf := NewScreenBuffer(1, 1)
+	ss.Draw(buf, buf.Bounds())
+	if got := buf.CellAt(0, 0).Link.URL; got != destination {
+		t.Errorf("Draw hyperlink length = %d, want %d", len(got), len(destination))
+	}
+}
+
+func TestStyledStringHyperlinkTermination(t *testing.T) {
+	const destination = "https://example.com"
+	linked := Link{URL: destination}
+	tests := []struct {
+		name string
+		seq  string
+		want Link
+	}{
+		{"7-bit OSC with BEL", "\x1b]8;;" + destination + "\a", linked},
+		{"7-bit OSC with ST", "\x1b]8;;" + destination + "\x1b\\", linked},
+		{"C1 OSC with BEL", "\x9d8;;" + destination + "\a", linked},
+		{"C1 OSC with ST", "\x9d8;;" + destination + "\x1b\\", linked},
+		{"7-bit OSC with C1 ST", "\x1b]8;;" + destination + "\x9c", Link{}},
+		{"C1 OSC with C1 ST", "\x9d8;;" + destination + "\x9c", Link{}},
+		{"unterminated 7-bit OSC", "\x1b]8;;" + destination + "\x1b[31m", Link{}},
+		{"unterminated C1 OSC", "\x9d8;;" + destination + "\x1b[31m", Link{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := NewStyledString(tc.seq + "x").Lines(ansi.GraphemeWidth)
+			if len(lines) != 1 || len(lines[0]) != 1 {
+				t.Fatalf("Lines = %#v, want one cell", lines)
+			}
+			if got := lines[0][0].Link; got != tc.want {
+				t.Errorf("link = %#v, want %#v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/styled_test.go
+++ b/styled_test.go
@@ -486,7 +486,7 @@ func TestStyledStringEmptyLines(t *testing.T) {
 }
 
 func TestStyledStringLinesUnboundedContent(t *testing.T) {
-	destination := strings.Repeat("a", 5000)
+	const destination = "https://example.com"
 	input := "\x1b[31mab\x1b[0m\n" + ansi.SetHyperlink(destination, "") + "界" + ansi.ResetHyperlink()
 	lines := NewStyledString(input).Lines(ansi.GraphemeWidth)
 
@@ -495,6 +495,22 @@ func TestStyledStringLinesUnboundedContent(t *testing.T) {
 	}
 	if cell := lines[1][0]; cell.Width != 2 || cell.Link.URL != destination {
 		t.Fatalf("linked cell = %#v, want width 2 and link %q", cell, destination)
+	}
+}
+
+func TestStyledStringLongHyperlink(t *testing.T) {
+	const parserDataLimit = 4 << 10
+	destination := strings.Repeat("a", parserDataLimit+1)
+	ss := NewStyledString(ansi.SetHyperlink(destination) + "x" + ansi.ResetHyperlink())
+
+	if got := ss.Lines(ansi.GraphemeWidth)[0][0].Link.URL; got != destination {
+		t.Errorf("Lines hyperlink length = %d, want %d", len(got), len(destination))
+	}
+
+	buf := NewScreenBuffer(1, 1)
+	ss.Draw(buf, buf.Bounds())
+	if got := buf.CellAt(0, 0).Link.URL; got != destination {
+		t.Errorf("Draw hyperlink length = %d, want %d", len(got), len(destination))
 	}
 }
 

--- a/styled_test.go
+++ b/styled_test.go
@@ -486,7 +486,7 @@ func TestStyledStringEmptyLines(t *testing.T) {
 }
 
 func TestStyledStringLinesUnboundedContent(t *testing.T) {
-	const destination = "https://example.com"
+	destination := strings.Repeat("a", 5000)
 	input := "\x1b[31mab\x1b[0m\n" + ansi.SetHyperlink(destination, "") + "界" + ansi.ResetHyperlink()
 	lines := NewStyledString(input).Lines(ansi.GraphemeWidth)
 

--- a/styled_test.go
+++ b/styled_test.go
@@ -501,44 +501,8 @@ func TestStyledStringLinesUnboundedContent(t *testing.T) {
 func TestStyledStringLongHyperlink(t *testing.T) {
 	const parserDataLimit = 4 << 10
 	destination := strings.Repeat("a", parserDataLimit+1)
-	ss := NewStyledString(ansi.SetHyperlink(destination) + "x" + ansi.ResetHyperlink())
-
-	if got := ss.Lines(ansi.GraphemeWidth)[0][0].Link.URL; got != destination {
+	if got := NewStyledString(ansi.SetHyperlink(destination) + "x").Lines(ansi.GraphemeWidth)[0][0].Link.URL; got != destination {
 		t.Errorf("Lines hyperlink length = %d, want %d", len(got), len(destination))
-	}
-
-	buf := NewScreenBuffer(1, 1)
-	ss.Draw(buf, buf.Bounds())
-	if got := buf.CellAt(0, 0).Link.URL; got != destination {
-		t.Errorf("Draw hyperlink length = %d, want %d", len(got), len(destination))
-	}
-}
-
-func TestOscPayload(t *testing.T) {
-	const payload = "8;;https://example.com"
-	tests := []struct {
-		name string
-		seq  string
-		want string
-		ok   bool
-	}{
-		{"7-bit OSC with BEL", "\x1b]" + payload + "\x07", payload, true},
-		{"7-bit OSC with ST", "\x1b]" + payload + "\x1b\\", payload, true},
-		{"C1 OSC with BEL", "\x9d" + payload + "\x07", payload, true},
-		{"C1 OSC with ST", "\x9d" + payload + "\x1b\\", payload, true},
-		{"empty payload", "\x1b]\x1b\\", "", true},
-		{"not OSC", payload + "\x07", "", false},
-		{"unterminated", "\x1b]" + payload, "", false},
-		{"bare introducer", "\x1b]", "", false},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, ok := oscPayload(tc.seq)
-			if got != tc.want || ok != tc.ok {
-				t.Errorf("oscPayload(%q) = (%q, %v), want (%q, %v)", tc.seq, got, ok, tc.want, tc.ok)
-			}
-		})
 	}
 }
 

--- a/styled_test.go
+++ b/styled_test.go
@@ -524,10 +524,8 @@ func TestOscPayload(t *testing.T) {
 	}{
 		{"7-bit OSC with BEL", "\x1b]" + payload + "\x07", payload, true},
 		{"7-bit OSC with ST", "\x1b]" + payload + "\x1b\\", payload, true},
-		{"7-bit OSC with C1 ST", "\x1b]" + payload + "\x9c", payload, true},
 		{"C1 OSC with BEL", "\x9d" + payload + "\x07", payload, true},
 		{"C1 OSC with ST", "\x9d" + payload + "\x1b\\", payload, true},
-		{"C1 OSC with C1 ST", "\x9d" + payload + "\x9c", payload, true},
 		{"empty payload", "\x1b]\x1b\\", "", true},
 		{"not OSC", payload + "\x07", "", false},
 		{"unterminated", "\x1b]" + payload, "", false},

--- a/styled_test.go
+++ b/styled_test.go
@@ -498,6 +498,36 @@ func TestStyledStringLinesUnboundedContent(t *testing.T) {
 	}
 }
 
+func TestOscPayload(t *testing.T) {
+	const payload = "8;;https://example.com"
+	tests := []struct {
+		name string
+		seq  string
+		want string
+		ok   bool
+	}{
+		{"7-bit OSC with BEL", "\x1b]" + payload + "\x07", payload, true},
+		{"7-bit OSC with ST", "\x1b]" + payload + "\x1b\\", payload, true},
+		{"7-bit OSC with C1 ST", "\x1b]" + payload + "\x9c", payload, true},
+		{"C1 OSC with BEL", "\x9d" + payload + "\x07", payload, true},
+		{"C1 OSC with ST", "\x9d" + payload + "\x1b\\", payload, true},
+		{"C1 OSC with C1 ST", "\x9d" + payload + "\x9c", payload, true},
+		{"empty payload", "\x1b]\x1b\\", "", true},
+		{"not OSC", payload + "\x07", "", false},
+		{"unterminated", "\x1b]" + payload, "", false},
+		{"bare introducer", "\x1b]", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := oscPayload(tc.seq)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("oscPayload(%q) = (%q, %v), want (%q, %v)", tc.seq, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
 func newWcCell(s string, style *Style, link *Link) Cell {
 	c := NewCell(ansi.WcWidth, s)
 	if style != nil {


### PR DESCRIPTION
Fixes #173

To handle longer links, we're extracting the OCS payload out of input value. 

In this way, we don't have to allocate anything extra to handle longer links.

---

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
