### PR TITLE
perf(renderer): reuse the touch records instead of reallocating them

### DIFF
--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -1534,11 +1534,6 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 					FirstCell: -1, LastCell: -1,
 				}
 			}
-			if i < len(s.curbuf.Touched) && i < s.curbuf.Height()-1 {
-				s.curbuf.Touched[i] = &LineData{
-					FirstCell: -1, LastCell: -1,
-				}
-			}
 		}
 	}
 
@@ -1553,7 +1548,6 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 		newbuf.Touched = make([]*LineData, newHeight)
 	}
 	resetTouched(newbuf.Touched)
-	resetTouched(s.curbuf.Touched)
 
 	s.updatePen(nil) // nil indicates a blank cell with no styles
 }

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -1514,17 +1514,11 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 	}
 
 	// Sync windows and screen
-	newbuf.Touched = make([]*LineData, newHeight)
-	for i := range newbuf.Touched {
-		newbuf.Touched[i] = &LineData{
-			FirstCell: -1, LastCell: -1,
-		}
+	if len(newbuf.Touched) != newHeight {
+		newbuf.Touched = make([]*LineData, newHeight)
 	}
-	for i := range s.curbuf.Touched {
-		s.curbuf.Touched[i] = &LineData{
-			FirstCell: -1, LastCell: -1,
-		}
-	}
+	resetTouched(newbuf.Touched)
+	resetTouched(s.curbuf.Touched)
 
 	s.updatePen(nil) // nil indicates a blank cell with no styles
 }
@@ -1916,4 +1910,16 @@ func xtermCaps(termtype string) (v capabilities) {
 	}
 
 	return v
+}
+
+// resetTouched marks every line as untouched, reusing the records already there
+// rather than allocating a new one per line on every render.
+func resetTouched(touched []*LineData) {
+	for i, ld := range touched {
+		if ld == nil {
+			touched[i] = &LineData{FirstCell: -1, LastCell: -1}
+			continue
+		}
+		ld.FirstCell, ld.LastCell = -1, -1
+	}
 }

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -1528,10 +1528,15 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 				changedLines++
 			}
 
-			// Mark line changed successfully.
+			// Mark line changed successfully, reusing the record rather than
+			// replacing it. Allocating one per row per render is what made the
+			// cost of a frame scale with the height of the screen, and
+			// resetTouched overwrites this one again on the way out regardless.
 			if i < len(newbuf.Touched) && i <= newbuf.Height()-1 {
-				newbuf.Touched[i] = &LineData{
-					FirstCell: -1, LastCell: -1,
+				if ld := newbuf.Touched[i]; ld != nil {
+					ld.FirstCell, ld.LastCell = -1, -1
+				} else {
+					newbuf.Touched[i] = &LineData{FirstCell: -1, LastCell: -1}
 				}
 			}
 		}

--- a/terminal_renderer.go
+++ b/terminal_renderer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"hash/maphash"
 	"io"
-	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -150,6 +149,7 @@ type TerminalRenderer struct {
 	noWrapLine       bool         // whether autowrap is off for the line currently being transformed
 	driftRows        []bool       // rows holding a cell the terminal may measure differently
 	lastW, lastH     int          // the size [TerminalRenderer.Resize] was last told
+	damaged          []bool       // rows this render disturbed itself, see [TerminalRenderer.damage]
 	logger           Logger       // The logger used for debugging.
 
 	// profile is the color profile to use when downsampling colors. This is
@@ -1364,6 +1364,39 @@ func (s *TerminalRenderer) Flush() (err error) {
 	return
 }
 
+// damage marks n rows from y as rows this render disturbed on its own: rows it
+// scrolled, rows it erased, rows the terminal is about to measure differently
+// than the model does. The diff loop paints a damaged row whether or not the
+// application drew into it, because the application has no reason to redraw a
+// row it did not change and no way to know the renderer moved it.
+//
+// This is the renderer talking to itself, so it is kept here rather than
+// written into the frame it was handed. A row the renderer disturbed and a row
+// the application drew into need the same treatment but mean different things,
+// and only one of them is the caller's to know about.
+func (s *TerminalRenderer) damage(y, n int) {
+	if y < 0 || n <= 0 {
+		return
+	}
+	if end := y + n; len(s.damaged) < end {
+		s.damaged = append(s.damaged, make([]bool, end-len(s.damaged))...)
+	}
+	for i := y; i < y+n; i++ {
+		s.damaged[i] = true
+	}
+}
+
+// damagedRow reports whether this render disturbed row y itself.
+func (s *TerminalRenderer) damagedRow(y int) bool {
+	return y >= 0 && y < len(s.damaged) && s.damaged[y]
+}
+
+// forgetDamage ends this render's account of what it disturbed. The slice is
+// kept, so a steady stream of frames allocates nothing.
+func (s *TerminalRenderer) forgetDamage() {
+	clear(s.damaged)
+}
+
 // Redraw forces a full redraw of the screen. It's equivalent to calling
 // [TerminalRenderer.Erase] and [TerminalRenderer.Render].
 func (s *TerminalRenderer) Redraw(newbuf *RenderBuffer) {
@@ -1395,10 +1428,13 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 	// application touched it. Rows of plain cells are measured the same by
 	// everyone and are left alone, so an ASCII screen pays nothing.
 	//
-	// Cloned because the diff loop below updates driftRows as it goes.
-	var repaintRows []bool
+	// Recorded before the loop, which updates driftRows as it goes.
 	if curWidth != newWidth {
-		repaintRows = slices.Clone(s.driftRows)
+		for y, drifts := range s.driftRows {
+			if drifts {
+				s.damage(y, 1)
+			}
+		}
 	}
 
 	if curWidth != newWidth || curHeight != newHeight {
@@ -1453,11 +1489,8 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 		s.clearBelow(newbuf, nil, eraseRow)
 
 		// The erase starts at the last row of the new frame, so it takes that
-		// row with it on the way down. The diff loop only visits rows the
-		// application drew into, and the application has no reason to draw into
-		// a row it did not change, so mark it here or the erase is the last
-		// thing that happens to it.
-		s.touchLine(newbuf, eraseRow, 1, true)
+		// row with it on the way down.
+		s.damage(eraseRow, 1)
 	}
 
 	// Resize the model before diffing so the loop below walks every row
@@ -1488,7 +1521,7 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 
 		nonEmpty = s.clearBottom(newbuf, nonEmpty)
 		for i = 0; i < nonEmpty; i++ {
-			if (i < len(repaintRows) && repaintRows[i]) ||
+			if s.damagedRow(i) ||
 				newbuf.Touched == nil || i >= len(newbuf.Touched) || (newbuf.Touched[i] != nil &&
 				(newbuf.Touched[i].FirstCell != -1 || newbuf.Touched[i].LastCell != -1)) {
 				s.transformLine(newbuf, i)
@@ -1512,6 +1545,8 @@ func (s *TerminalRenderer) Render(newbuf *RenderBuffer) {
 	if !s.flags.Contains(tFullscreen) && (curWidth != newWidth || curHeight != newHeight) {
 		s.move(newbuf, 0, max(newHeight-1, 0))
 	}
+
+	s.forgetDamage()
 
 	// Sync windows and screen
 	if len(newbuf.Touched) != newHeight {

--- a/terminal_renderer_hardscroll.go
+++ b/terminal_renderer_hardscroll.go
@@ -149,25 +149,6 @@ func (s *TerminalRenderer) scrollBuffer(b *RenderBuffer, n, top, bot int, blank 
 			b.FillArea(blank, Rect(0, line, b.Width(), 1))
 		}
 	}
-
-	s.touchLine(b, top, bot-top+1, true)
-}
-
-// touchLine marks the line as touched.
-func (s *TerminalRenderer) touchLine(newbuf *RenderBuffer, y, n int, changed bool) {
-	height := newbuf.Height()
-	if n < 0 || y < 0 || y >= height || newbuf.Touched == nil || len(newbuf.Touched) < height {
-		return // Nothing to touch
-	}
-
-	width := newbuf.Width()
-	for i := y; i < y+n && i < height && i < len(newbuf.Touched); i++ {
-		if changed {
-			newbuf.TouchLine(0, i, width)
-		} else {
-			newbuf.Touched[i] = nil
-		}
-	}
 }
 
 // scrollUp scrolls the screen up by n lines.

--- a/terminal_renderer_hardscroll.go
+++ b/terminal_renderer_hardscroll.go
@@ -110,11 +110,10 @@ func (s *TerminalRenderer) scrolln(newbuf *RenderBuffer, n, top, bot, maxY int) 
 
 	s.scrollBuffer(s.curbuf, n, top, bot, blank)
 
-	// The scroll moved rows the application never drew into, and the diff loop
-	// only visits rows the application touched. Mark the whole scrolled range
-	// so every row it moved is compared against the model again; a row the
-	// scroll already put right costs a comparison and no output.
-	s.touchLine(newbuf, top, bot-top+1, true)
+	// Every row in the range moved, whether or not the application drew into
+	// it. A row the scroll already put in the right place costs a comparison
+	// and no output, which is the whole point of scrolling in hardware.
+	s.damage(top, bot-top+1)
 
 	// shift hash values too, they can be reused
 	s.scrollOldhash(n, top, bot)

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -2023,3 +2023,52 @@ func TestRendererScrollRepaintsRowsItMoved(t *testing.T) {
 		t.Errorf("scrolled rows painted %d times, want 2 (rows 1 and 2): %q", n, out)
 	}
 }
+
+// The renderer's record of the rows it disturbed itself. The guard matters:
+// the erase below a shrinking inline frame damages row newHeight-1, which is
+// -1 for an empty frame, and a render that walks no rows still has to leave
+// the record clean for the next one.
+func TestRendererDamageRecord(t *testing.T) {
+	var r TerminalRenderer
+
+	if r.damagedRow(0) {
+		t.Error("a renderer that has disturbed nothing reports damage")
+	}
+
+	r.damage(2, 3)
+	for y, want := range map[int]bool{0: false, 1: false, 2: true, 3: true, 4: true, 5: false} {
+		if got := r.damagedRow(y); got != want {
+			t.Errorf("after damage(2, 3), row %d damaged=%v, want %v", y, got, want)
+		}
+	}
+
+	// Out of range in either direction is a question, not a panic.
+	if r.damagedRow(-1) || r.damagedRow(1<<20) {
+		t.Error("a row outside the record reports damage")
+	}
+
+	// Nothing to mark, nothing marked. A negative row is what an empty frame
+	// asks about, and n of zero is a range that does not exist.
+	before := len(r.damaged)
+	r.damage(-1, 1)
+	r.damage(0, 0)
+	r.damage(0, -1)
+	if len(r.damaged) != before {
+		t.Errorf("a degenerate range grew the record from %d to %d", before, len(r.damaged))
+	}
+	if r.damagedRow(0) {
+		t.Error("damage(0, 0) marked row 0")
+	}
+
+	// The record is per render. Forgetting keeps the space it already has, so
+	// a steady stream of frames stops allocating.
+	r.forgetDamage()
+	for y := range 6 {
+		if r.damagedRow(y) {
+			t.Errorf("row %d still damaged after forgetDamage", y)
+		}
+	}
+	if len(r.damaged) != before {
+		t.Errorf("forgetDamage resized the record to %d, want %d kept", len(r.damaged), before)
+	}
+}


### PR DESCRIPTION
refactor the damage set code replacing the touch list