### PR TITLE
fix(renderer): survive a touch list shorter than the screen

### DIFF
--- a/terminal_renderer_hashmap.go
+++ b/terminal_renderer_hashmap.go
@@ -30,7 +30,12 @@ func (s *TerminalRenderer) updateHashmap(newbuf *RenderBuffer) {
 	if len(s.oldhash) >= height && len(s.newhash) >= height {
 		// rehash changed lines
 		for i := range height {
-			if newbuf.Touched == nil || newbuf.Touched[i] != nil {
+			// A touch list shorter than the screen is not a contradiction: an
+			// application may drop the list and touch one row, and the list
+			// grows only as far as the rows it was told about. Rows past the end
+			// are rows nobody claimed either way, so rehash them, which is what
+			// a missing list means here too.
+			if i >= len(newbuf.Touched) || newbuf.Touched[i] != nil {
 				// TODO: Investigate why this is needed. If we remove this
 				// line, scroll optimization does not work correctly. This
 				// should happen else where.

--- a/terminal_renderer_test.go
+++ b/terminal_renderer_test.go
@@ -2072,3 +2072,37 @@ func TestRendererDamageRecord(t *testing.T) {
 		t.Errorf("forgetDamage resized the record to %d, want %d kept", len(r.damaged), before)
 	}
 }
+
+// A touch list shorter than the screen is a state an application can reach: drop
+// the list, which is what an application does when it knows the frame changed
+// shape, then touch one row. The list grows only as far as the rows it was told
+// about, so it ends up shorter than the screen while the screen keeps its
+// height, and the scroll optimisation walked every row of the screen through
+// it.
+//
+// The dimensions have to stay put for this, since a change of size discards the
+// hashes and takes the rehash-everything path that never indexes the list.
+func TestRendererHashesAShortTouchList(t *testing.T) {
+	r := NewTerminalRenderer(io.Discard, []string{"TERM=xterm-256color"})
+	r.SetFullscreen(true)
+	r.SetScrollOptim(true)
+
+	cellbuf := NewRenderBuffer(5, 4)
+	cellbuf.SetCell(0, 0, &Cell{Content: "a", Width: 1})
+	r.Render(cellbuf)
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+
+	cellbuf.Touched = nil
+	cellbuf.SetCell(0, 0, &Cell{Content: "b", Width: 1})
+	if len(cellbuf.Touched) >= cellbuf.Height() {
+		t.Fatalf("expected a touch list shorter than the %d-row screen, got %d rows",
+			cellbuf.Height(), len(cellbuf.Touched))
+	}
+
+	r.Render(cellbuf) // indexed the list by screen row and ran off the end
+	if err := r.Flush(); err != nil {
+		t.Fatalf("failed to flush renderer: %v", err)
+	}
+}


### PR DESCRIPTION
Found while adversarially reviewing the stack below this one. It is not a
regression from any of those commits — it reproduces on `main` — but the review
that turned it up belongs to them, so it lands here rather than waiting.

`updateHashmap` walks every row of the screen and asks the frame's touch list
about each one, having checked only that the list exists:

```go
if newbuf.Touched == nil || newbuf.Touched[i] != nil {
```

A list shorter than the screen panics it:

```
panic: runtime error: index out of range [1] with length 1
  uv.(*TerminalRenderer).updateHashmap  terminal_renderer_hashmap.go:33
  uv.(*TerminalRenderer).scrollOptimize terminal_renderer_hardscroll.go:18
  uv.(*TerminalRenderer).Render         terminal_renderer.go
```

That is a state an application can reach, and one it has a reason to: drop the
list, which is what you do when the frame changed shape and last frame's record
of what moved means nothing, then touch a row. `TouchLine` grows the list only
as far as the rows it is told about, so it ends up shorter than the screen while
the screen keeps its height. Bubble Tea does exactly this in `cursed_renderer.go`
and escapes only because it follows the drop with a resize and a clear, which
touches every row and restores the length.

Needs `SetScrollOptim(true)` and fullscreen to reach, and the dimensions have to
stay put, since a change of size discards the hashes and takes the
rehash-everything path that never indexes the list.

The fix asks about the index before using it, the way the diff loop already
does. Rows past the end are rows nobody claimed either way, so they rehash,
which is what a missing list already meant — so the guard is a widening of the
existing `== nil` case rather than a new branch.